### PR TITLE
Return extensions and make `describe` visual

### DIFF
--- a/gto/api.py
+++ b/gto/api.py
@@ -1,6 +1,6 @@
 from collections import OrderedDict
 from datetime import datetime
-from typing import List, Optional, Union
+from typing import Dict, List, Optional, Union
 
 from git import Repo
 
@@ -255,7 +255,7 @@ def _is_ascending(sort):
 
 def describe(
     repo: Union[str, Repo], name: str, rev: str = None
-) -> List[EnrichmentInfo]:
+) -> Dict[str, EnrichmentInfo]:
     """Find enrichments for the artifact"""
     ref_type, parsed = parse_name_reference(name)
     if ref_type == NAME_REFERENCE.NAME:

--- a/gto/constants.py
+++ b/gto/constants.py
@@ -1,5 +1,8 @@
 from enum import Enum
 
+GTO = "gto"
+MLEM = "mlem"
+
 REF = "ref"
 # COMMIT = "commit"
 TAG = "tag"
@@ -7,12 +10,14 @@ TAG = "tag"
 # FILE = "file"
 
 ACTION = "action"
-TYPE = "type"
 NAME = "name"
-PATH = "path"
 VERSION = "version"
 STAGE = "stage"
 NUMBER = "number"
+
+TYPE = "type"
+PATH = "path"
+DESCRIPTION = "description"
 
 
 class Action(Enum):

--- a/gto/ext_mlem.py
+++ b/gto/ext_mlem.py
@@ -1,39 +1,39 @@
-# """This is temporary file that should be moved to mlem.gto module"""
-# from typing import Optional
+"""This is temporary file that should be moved to mlem.gto module"""
+from typing import Optional
 
-# from git import Repo
-# from mlem.core.errors import MlemObjectNotFound
-# from mlem.core.metadata import load_meta
-# from mlem.core.objects import DatasetMeta, MlemMeta, ModelMeta
-# from pydantic import BaseModel
+from git import Repo
+from mlem.core.errors import MlemObjectNotFound
+from mlem.core.metadata import load_meta
+from mlem.core.objects import DatasetMeta, MlemMeta, ModelMeta
+from pydantic import BaseModel
 
-# from gto.ext import Enrichment, EnrichmentInfo
-
-
-# class MlemInfo(EnrichmentInfo):
-#     source = "mlem"
-#     meta: MlemMeta
-
-#     def get_object(self) -> BaseModel:
-#         return self.meta
-
-#     def get_human_readable(self) -> str:
-#         # TODO: create `.describe` method in MlemMeta https://github.com/iterative/mlem/issues/98
-#         description = f"""Mlem {self.meta.object_type}"""
-#         if isinstance(self.meta, ModelMeta):
-#             description += f": {self.meta.model_type.type}"
-#         if isinstance(self.meta, DatasetMeta):
-#             description += f": {self.meta.dataset.dataset_type.type}"
-#         return description
+from gto.ext import Enrichment, EnrichmentInfo
 
 
-# class MlemEnrichment(Enrichment):
-#     source = "mlem"
+class MlemInfo(EnrichmentInfo):
+    source = "mlem"
+    meta: MlemMeta
 
-#     def describe(self, repo, obj: str, rev: Optional[str]) -> Optional[MlemInfo]:
-#         try:
-#             if isinstance(repo, Repo):
-#                 repo = repo.working_dir
-#             return MlemInfo(meta=load_meta(obj, repo=repo))  # rev=rev
-#         except MlemObjectNotFound:
-#             return None
+    def get_object(self) -> BaseModel:
+        return self.meta
+
+    def get_human_readable(self) -> str:
+        # TODO: create `.describe` method in MlemMeta https://github.com/iterative/mlem/issues/98
+        description = f"""Mlem {self.meta.object_type}"""
+        if isinstance(self.meta, ModelMeta):
+            description += f": {self.meta.model_type.type}"
+        if isinstance(self.meta, DatasetMeta):
+            description += f": {self.meta.dataset.dataset_type.type}"
+        return description
+
+
+class MlemEnrichment(Enrichment):
+    source = "mlem"
+
+    def describe(self, repo, obj: str, rev: Optional[str]) -> Optional[MlemInfo]:
+        try:
+            if isinstance(repo, Repo):
+                repo = repo.working_dir
+            return MlemInfo(meta=load_meta(obj, repo=repo))  # rev=rev
+        except MlemObjectNotFound:
+            return None

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ setup_args = dict(  # noqa: C408
     entry_points={
         "console_scripts": ["gto = gto.cli:app"],
         "gto.enrichment": [
-            # "mlem = gto.ext_mlem:MlemEnrichment",
+            "mlem = gto.ext_mlem:MlemEnrichment",
             # "dvc = gto.ext_dvc:DVCEnrichment",
             # "cli = gto.ext:CLIEnrichment",
             "gto = gto.index:GTOEnrichment",


### PR DESCRIPTION
This PR uncomments MLEM extension and creates visual representation of `gto describe` resembling Model Card in Studio. WIP example:

<img width="1648" alt="image" src="https://user-images.githubusercontent.com/6797716/166679374-f693d066-4b61-4743-a59e-70a79c9b828e.png">

The model card from the screenshot was printed upon calling `gto describe ml-model`.