### PR TITLE
Enhance sorting

### DIFF
--- a/gto/api.py
+++ b/gto/api.py
@@ -383,7 +383,7 @@ def history(  # pylint: disable=too-many-locals
         commits + registration + promotion,
         key=lambda x: (x["timestamp"], events_order[x["event"]]),
     )
-    if ascending:
+    if not ascending:
         events.reverse()
     if artifact:
         events = [event for event in events if event["artifact"] == artifact]

--- a/gto/base.py
+++ b/gto/base.py
@@ -75,6 +75,42 @@ class BaseArtifact(BaseModel):
         stages = ", ".join(f"'{l}'" for l in self.unique_stages)
         return f"Artifact(versions=[{versions}], stages=[{stages}])"
 
+    @staticmethod
+    def sort_versions(
+        versions,
+        sort=VersionSort.SemVer,
+        ascending=False,
+    ):
+        sort = sort if isinstance(sort, VersionSort) else VersionSort[sort]
+        if sort == VersionSort.SemVer:
+            # sorting SemVer versions in a right way
+            sorted_versions = sorted(
+                (v for v in versions if v.is_registered),
+                key=lambda x: x.version,
+            )[:: 1 if ascending else -1]
+            # sorting hexsha versions alphabetically
+            sorted_versions.extend(
+                sorted(
+                    (v for v in versions if not v.is_registered and not v.discovered),
+                    key=lambda x: x.name,
+                )[:: 1 if ascending else -1]
+            )
+            # sorting discovered hexsha versions alphabetically
+            sorted_versions.extend(
+                sorted(
+                    (v for v in versions if v.discovered),
+                    key=lambda x: x.name,
+                )[:: 1 if ascending else -1]
+            )
+        else:
+            sorted_versions = sorted(
+                versions,
+                key=lambda x: x.created_at,
+            )[:: 1 if ascending else -1]
+        if ascending:
+            sorted_versions.reverse()
+        return sorted_versions
+
     def get_versions(
         self,
         include_non_explicit=False,
@@ -82,44 +118,14 @@ class BaseArtifact(BaseModel):
         sort=VersionSort.SemVer,
         ascending=False,
     ) -> List[BaseVersion]:
-        sort = sort if isinstance(sort, VersionSort) else VersionSort[sort]
-        all_versions = [
+        versions = [
             v
             for v in self.versions
             if (v.is_registered and not v.discovered)
             or (include_discovered and v.discovered)
             or (include_non_explicit and not v.is_registered)
         ]
-        if sort == VersionSort.SemVer:
-            # sorting SemVer versions in a right way
-            versions = sorted(
-                (v for v in all_versions if not v.discovered and v.is_registered),
-                key=lambda x: x.version,
-            )
-            # sorting hexsha versions alphabetically
-            if include_non_explicit:
-                versions.extend(
-                    sorted(
-                        (
-                            v
-                            for v in all_versions
-                            if not v.discovered and not v.is_registered
-                        ),
-                        key=lambda x: x.name,
-                    )
-                )
-        else:
-            versions = sorted(
-                (
-                    v
-                    for v in all_versions
-                    if not v.discovered and (include_non_explicit or v.is_registered)
-                ),
-                key=lambda x: x.created_at,
-            )
-        if ascending:
-            versions.reverse()
-        return versions
+        return self.sort_versions(versions, sort=sort, ascending=ascending)
 
     def get_latest_version(
         self, registered_only=False, sort=VersionSort.SemVer
@@ -128,7 +134,7 @@ class BaseArtifact(BaseModel):
             include_non_explicit=not registered_only, sort=sort
         )
         if versions:
-            return versions[-1]
+            return versions[0]
         return None
 
     def get_promotions(
@@ -146,11 +152,9 @@ class BaseArtifact(BaseModel):
             promotion = version.stage
             if promotion:
                 stages[promotion.stage] = stages.get(promotion.stage, []) + [promotion]
-                # else:
-                #     stages[promotion.stage] = stages.get(promotion.stage) or promotion
         if all:
             return stages
-        return {stage: promotions[-1] for stage, promotions in stages.items()}
+        return {stage: promotions[0] for stage, promotions in stages.items()}
 
     def add_version(self, version: BaseVersion):
         self.versions.append(version)

--- a/gto/base.py
+++ b/gto/base.py
@@ -76,20 +76,13 @@ def sort_versions(
     if sort == VersionSort.SemVer:
         # sorting SemVer versions in a right way
         sorted_versions = sorted(
-            (v for v in versions if v.is_registered),
+            (v for v in versions if SemVer.is_valid(get(v, version))),
             key=lambda x: SemVer(get(x, version)),
         )[:: 1 if ascending else -1]
         # sorting hexsha versions alphabetically
         sorted_versions.extend(
             sorted(
-                (v for v in versions if not v.is_registered and not v.discovered),
-                key=lambda x: get(x, version),
-            )[:: 1 if ascending else -1]
-        )
-        # sorting discovered hexsha versions alphabetically
-        sorted_versions.extend(
-            sorted(
-                (v for v in versions if v.discovered),
+                (v for v in versions if not SemVer.is_valid(get(v, version))),
                 key=lambda x: get(x, version),
             )[:: 1 if ascending else -1]
         )
@@ -98,8 +91,8 @@ def sort_versions(
             versions,
             key=lambda x: get(x, timestamp),
         )[:: 1 if ascending else -1]
-    if ascending:
-        sorted_versions.reverse()
+    # if ascending:
+    #     sorted_versions.reverse()
     return sorted_versions
 
 

--- a/gto/cli.py
+++ b/gto/cli.py
@@ -543,7 +543,7 @@ def which(
     ref: bool = option_ref_bool,
     all: bool = option_all,
     registered_only: bool = option_registered_only,
-    ascending: bool = option_ascending,
+    # ascending: bool = option_ascending,
 ):
     """Find the latest artifact version in a given stage
 
@@ -558,8 +558,8 @@ def which(
     )
     if version:
         if all:
-            if ascending:
-                version.reverse()
+            # if ascending:
+            #     version.reverse()
             format_echo([v.version for v in version], "lines")
         elif ref:
             echo(version.tag or version.commit_hexsha)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -106,7 +106,7 @@ def test_commands(showcase):
     _check_successful_cmd(
         "which",
         ["-r", path, "rf", "production", "--all", "--ascending"],
-        "v1.2.4\nv1.2.3\n",
+        "v1.2.3\nv1.2.4\n",
     )
     _check_successful_cmd(
         "which",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -105,8 +105,8 @@ def test_commands(showcase):
     )
     _check_successful_cmd(
         "which",
-        ["-r", path, "rf", "production", "--all", "--ascending"],
-        "v1.2.3\nv1.2.4\n",
+        ["-r", path, "rf", "production", "--all"],
+        "v1.2.4\nv1.2.3\n",
     )
     _check_successful_cmd(
         "which",


### PR DESCRIPTION
@amritghimire, please check out this PR. You need `def sort_versions` in `base.py`

Note, that BaseVersion in GTO has `is_registered` and `discovered` atrrs, which I use for sorting also. Not sure you have them already.

`is_registered == True` indicates that it's an explicitly registered SemVer, e.g. `v1.2.3`.
`is_registered == False` indicates that it wasn't explicitly registered, but model in this hexsha was promoted to some stage (e.g. with `model#prod#1` git tag). In this case GTO assumes it's a version, though not explicitly registered. For the version name, GTO uses commit hash.

Considering #132 `is_registered == False` maybe deprecated. But we need a decision there first.

cc @shcheklein: #132 is something I can use your help with.