### PR TITLE
Improve names validation

### DIFF
--- a/gto/config.py
+++ b/gto/config.py
@@ -22,7 +22,7 @@ CONFIG_FILE_NAME = ".gto"
 
 
 def check_name_is_valid(name):
-    return bool(re.match(r"[a-zA-Z0-9-/]*$", name))
+    return bool(re.match(r"[a-z][a-z0-9-/]*[a-z0-9]$", name))
 
 
 def assert_name_is_valid(name):

--- a/gto/registry.py
+++ b/gto/registry.py
@@ -6,7 +6,12 @@ from git import InvalidGitRepositoryError, NoSuchPathError, Repo
 from pydantic import BaseModel
 
 from gto.base import BasePromotion, BaseRegistryState
-from gto.config import CONFIG_FILE_NAME, RegistryConfig, read_registry_config
+from gto.config import (
+    CONFIG_FILE_NAME,
+    RegistryConfig,
+    assert_name_is_valid,
+    read_registry_config,
+)
 from gto.exceptions import (
     NoRepo,
     VersionAlreadyRegistered,
@@ -101,6 +106,7 @@ class GitRegistry(BaseModel):
         stdout=False,
     ):
         """Register artifact version"""
+        assert_name_is_valid(name)
         version_args = sum(
             bool(i) for i in (version, bump_major, bump_minor, bump_patch)
         )
@@ -170,6 +176,7 @@ class GitRegistry(BaseModel):
         stdout=False,
     ) -> BasePromotion:
         """Assign stage to specific artifact version"""
+        assert_name_is_valid(name)
         self.config.assert_stage(stage)
         if not (promote_version is None) ^ (promote_ref is None):
             raise WrongArgs("One and only one of (version, ref) must be specified.")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -7,7 +7,7 @@ from typer.testing import CliRunner
 
 from gto.api import annotate
 from gto.cli import app
-from gto.config import CONFIG_FILE_NAME
+from gto.config import CONFIG_FILE_NAME, check_name_is_valid
 from gto.exceptions import UnknownType
 from gto.index import init_index_manager
 from gto.registry import GitRegistry
@@ -55,3 +55,39 @@ def test_config_is_not_needed(empty_git_repo: Tuple[git.Repo, Callable], request
     result = runner.invoke(app, ["--help"])
     os.chdir(request.config.invocation_dir)
     assert result.exit_code == 0
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "nn",
+        "m1",
+        "model-prod",
+        "model-prod-v1",
+        "namespace/model",
+    ],
+)
+def test_check_name_is_valid(name):
+    assert check_name_is_valid(name)
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "",
+        "m",
+        "1",
+        "m/",
+        "/m",
+        "1nn",
+        "###",
+        "@@@",
+        "-model",
+        "model-",
+        "model@1",
+        "model#1",
+        "@namespace/model",
+    ],
+)
+def test_check_name_is_invalid(name):
+    assert not check_name_is_valid(name)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -5,10 +5,10 @@ import git
 import pytest
 from typer.testing import CliRunner
 
-from gto.api import annotate
+from gto.api import annotate, promote, register
 from gto.cli import app
 from gto.config import CONFIG_FILE_NAME, check_name_is_valid
-from gto.exceptions import UnknownType
+from gto.exceptions import UnknownType, ValidationError
 from gto.index import init_index_manager
 from gto.registry import GitRegistry
 
@@ -41,6 +41,40 @@ def test_adding_allowed_type(init_repo):
 def test_adding_not_allowed_type(init_repo):
     with pytest.raises(UnknownType):
         annotate(init_repo, "name", type="unknown")
+
+
+def test_correct_name(init_repo):
+    annotate(init_repo, "model")
+
+
+def test_incorrect_name(init_repo):
+    with pytest.raises(ValidationError):
+        annotate(init_repo, "###")
+
+
+def test_incorrect_type(init_repo):
+    with pytest.raises(ValidationError):
+        annotate(init_repo, "model", type="###")
+
+
+def test_register_incorrect_name(init_repo):
+    with pytest.raises(ValidationError):
+        register(init_repo, "###", ref="HEAD")
+
+
+# def test_register_incorrect_version(init_repo):
+#     with pytest.raises(ValidationError):
+#         register(init_repo, "model", ref="HEAD", version="###")
+
+
+def test_promote_incorrect_name(init_repo):
+    with pytest.raises(ValidationError):
+        promote(init_repo, "###", promote_ref="HEAD", stage="dev")
+
+
+def test_promote_incorrect_stage(init_repo):
+    with pytest.raises(ValidationError):
+        promote(init_repo, "model", promote_ref="HEAD", stage="###")
 
 
 def test_config_is_not_needed(empty_git_repo: Tuple[git.Repo, Callable], request):

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -25,9 +25,9 @@ def git_index_repo(empty_git_repo: Tuple[git.Repo, Callable]):
 def test_git_index_add_virtual(git_index_repo):
     index, repo = git_index_repo
     index.add(
-        "a",
-        type="a",
-        path="a",
+        "nn",
+        type="tt",
+        path="pp",
         must_exist=False,
         labels=[],
         description="",
@@ -37,7 +37,7 @@ def test_git_index_add_virtual(git_index_repo):
     new_index = init_index(repo.git_dir)
     assert isinstance(new_index, RepoIndexManager)
     index_value = new_index.get_index()
-    assert index_value.state["a"] == Artifact(path="a", type="a", virtual=True)
+    assert index_value.state["nn"] == Artifact(path="pp", type="tt", virtual=True)
 
     repo.index.add(CONFIG.INDEX)
     commit = repo.index.commit("add index")
@@ -47,12 +47,14 @@ def test_git_index_add_virtual(git_index_repo):
 
 def test_git_index_remove_virtual(git_index_repo):
     index, repo = git_index_repo
-    index.add("a", "a", "a", must_exist=False, labels=[], description="", update=True)
+    index.add(
+        "aa", "aa", "aa", must_exist=False, labels=[], description="", update=True
+    )
 
     new_index = init_index(repo.git_dir)
     assert isinstance(new_index, RepoIndexManager)
 
-    new_index.remove("a")
+    new_index.remove("aa")
     index_value = new_index.get_index()
     assert index_value.state == {}
 


### PR DESCRIPTION
closes #164 

@Suor, do you really need that check exposed in `mlem.api.check_name_is_valid`? It doesn't make sense to the casual user I think, that's why I'm not sure about this. It's accessible in config anyway.

TODO: check that names are correct upon reading/writing to `artifacts.yaml`, as well upon registration/promotions.