### PR TITLE
Change 'checkouted' to 'checked out'

### DIFF
--- a/gto/exceptions.py
+++ b/gto/exceptions.py
@@ -28,7 +28,7 @@ class WrongConfig(GTOException):
 
 
 class NoFile(GTOException):
-    _message = "No file/folder found in '{path}' for checkouted commit"
+    _message = "No file/folder found in '{path}' for checked out commit"
 
     def __init__(self, path) -> None:
         self.message = self._message.format(path=path)


### PR DESCRIPTION
Small typo I found in one of the exception messages while testing some stuff in GTO.