### PR TITLE
Support typer>=0.6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,7 +326,7 @@ $ pip install --upgrade pip setuptools wheel ".[tests]"
 ### 3. Run
 
 ```console
-$ pytest --basetemp=pytest-cache
+$ pytest --basetemp=.pytest-cache
 ```
 
 This will create `pytest-cache/` directory with some fixtures that can serve as
@@ -335,7 +335,7 @@ examples.
 Notably, check out this dir:
 
 ```console
-$ cd pytest-cache/test_api0/
+$ cd .pytest-cache/test_api0/
 $ gto show -v
 ```
 

--- a/gto/cli.py
+++ b/gto/cli.py
@@ -37,7 +37,7 @@ class GtoCliMixin(Command):
         aliases: List[str] = None,
         **kwargs,
     ):
-        super().__init__(name, **kwargs)
+        super().__init__(name=name, **kwargs)
         self.examples = examples
         self.section = section
         self.aliases = aliases
@@ -75,7 +75,7 @@ def _extract_examples(
     return help_str[examples + len("Examples:") + 1 :], help_str[:examples]
 
 
-class GtoCommand(TyperCommand, GtoCliMixin):
+class GtoCommand(GtoCliMixin, TyperCommand):
     def __init__(
         self,
         name: Optional[str],
@@ -86,7 +86,7 @@ class GtoCommand(TyperCommand, GtoCliMixin):
     ):
         examples, help = _extract_examples(help)
         super().__init__(
-            name,
+            name=name,
             section=section,
             aliases=aliases,
             examples=examples,
@@ -95,7 +95,7 @@ class GtoCommand(TyperCommand, GtoCliMixin):
         )
 
 
-class GtoGroup(TyperGroup, GtoCliMixin):
+class GtoGroup(GtoCliMixin, TyperGroup):
     order = [
         CommandGroups.querying,
         CommandGroups.modifying,

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import find_packages, setup
 
 install_requires = [
     "gitpython",
-    "typer<0.6",
+    "typer",
     "rich",
     "pydantic",
     "ruamel.yaml",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -42,7 +42,7 @@ def app_cmd():
 def app_cli_cmd(app_cmd):
     if version.parse(typer.__version__) < version.parse("0.6.0"):
         return (
-            get_command_from_info(c)  # pylint: disable=unexpected-keyword-arg
+            get_command_from_info(c)  # pylint: disable=missing-kwoa
             for c in app_cmd
         )
     return (

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -38,7 +38,10 @@ def app_cmd():
 
 @pytest.fixture
 def app_cli_cmd(app_cmd):
-    return (get_command_from_info(c) for c in app_cmd)
+    return (
+        get_command_from_info(c, pretty_exceptions_short=False, rich_markup_mode="rich")
+        for c in app_cmd
+    )
 
 
 def test_commands_help(app_cli_cmd):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -42,8 +42,7 @@ def app_cmd():
 def app_cli_cmd(app_cmd):
     if version.parse(typer.__version__) < version.parse("0.6.0"):
         return (
-            get_command_from_info(c)  # pylint: disable=missing-kwoa
-            for c in app_cmd
+            get_command_from_info(c) for c in app_cmd  # pylint: disable=missing-kwoa
         )
     return (
         get_command_from_info(  # pylint: disable=unexpected-keyword-arg

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -41,7 +41,10 @@ def app_cmd():
 @pytest.fixture
 def app_cli_cmd(app_cmd):
     if version.parse(typer.__version__) < version.parse("0.6.0"):
-        return (get_command_from_info(c) for c in app_cmd)
+        return (
+            get_command_from_info(c)  # pylint: disable=unexpected-keyword-arg
+            for c in app_cmd
+        )
     return (
         get_command_from_info(  # pylint: disable=unexpected-keyword-arg
             c,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,6 +3,8 @@ from typing import Callable, Optional, Tuple
 
 import git
 import pytest
+import typer
+from packaging import version
 from typer.main import get_command_from_info
 from typer.testing import CliRunner
 
@@ -38,8 +40,14 @@ def app_cmd():
 
 @pytest.fixture
 def app_cli_cmd(app_cmd):
+    if version.parse(typer.__version__) < version.parse("0.6.0"):
+        return (get_command_from_info(c) for c in app_cmd)
     return (
-        get_command_from_info(c, pretty_exceptions_short=False, rich_markup_mode="rich")
+        get_command_from_info(  # pylint: disable=unexpected-keyword-arg
+            c,
+            pretty_exceptions_short=False,
+            rich_markup_mode="rich",
+        )
         for c in app_cmd
     )
 


### PR DESCRIPTION
Solves issue https://github.com/iterative/gto/issues/212

I made test_cli.py compatible with typer~=0.5.0, not with typer~=0.4.0 (tests fail in that scenario).

I was wondering if it possible to automatically run the tests for the two different versions on typer. I could not find a good way.

EXTRA: small fix in the README.md (there was an inconsistency with gitignore)