### PR TITLE
Add `unassign` and `deprecate`

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,8 @@ This guide will walk you through the Lifecycle of an artifact. To execute each
 step, you'll need to create a Git tag of a special format, which will trigger CI
 and trigger the job you intend to run:
 
-1. Registering it - marking the very beginning of the artifact history in the
-   Git repository.
+1. Registering artifact - marking the very beginning of the artifact history in
+   the Git repository.
 2. Publishing a version - marking an important change in the artifact.
 3. Assigning a stage to a version - marking the readiness to be consumed by a
    downstream system.

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Created Git tag `awesome-model@` that registers the artifact.
 
 This can be done to mark the very beginning of the artifact history, so it's
 better to create this tag for the very first commit the artifact was present in
-(even not annotated - see below what an annotation is).
+(even if not annotated - see below what an annotation is).
 
 ### Versioning an artifact
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ consumer. You can plug in a real downsteam system via CI/CD or web hooks, e.g.
 to redeploy an ML model.
 
 ```console
-$ gto tag awesome-model --stage prod
+$ gto tag awesome-model --version v0.0.1 --stage prod
 Created git tag 'awesome-model#prod#1'
 ```
 
@@ -95,10 +95,10 @@ require deleting the existing tag.
 
 ### Annotating
 
-So far we've seen how to register new version and assign a stage to an artifact
-versions, but we still don't have much information about them. What about the
-type of artifact (dataset, model, etc.) or the file path to find it in the
-working tree?
+So far we've seen how to register a new version and assign a stage to an
+artifact versions, but we still don't have much information about them. What
+about the type of artifact (dataset, model, etc.) or the file path to find it in
+the working tree?
 
 For simple projects (e.g. single artifact) we can assume the details in a
 downstream system. But for more advanced cases, we should codify them in the
@@ -151,7 +151,7 @@ consumer, and maybe signal a downstream system about this. You can use
 `gto untag` for that:
 
 ```console
-$ gto untag awesome-model --stage prod
+$ gto untag awesome-model --version v0.0.1 --stage prod
 Created git tag 'awesome-model#prod#2!'
 ```
 
@@ -169,7 +169,7 @@ and don't want to trigger a CI/CD or another downstream system. For that, you
 can use:
 
 ```console
-$ gto untag --stage prod --delete
+$ gto untag awesome-model --version v0.0.1 --stage prod --delete
 Deleted git tag 'awesome-model#prod#1'
 To push the changes upstream, run:
 git push origin awesome-model#prod#1 --delete

--- a/README.md
+++ b/README.md
@@ -47,10 +47,10 @@ $ cd example-gto
 
 Registering a version is usually done to mark significant changes to the
 artifact. To release a new version (including the very first one), use
-`gto tag`.
+`gto register`.
 
 ```console
-$ gto tag awesome-model --version v0.0.1
+$ gto register awesome-model HEAD --version v0.0.1
 Created git tag 'awesome-model@v0.0.1' that registers a version
 ```
 
@@ -61,19 +61,19 @@ GTO creates a special Git tag for the artifact version, in a standard format:
 
 The version is now associated to the current Git commit (`HEAD`). You can use
 another Git commit if you provide it's hexsha as an additional argument, like
-`$ gto tag awesome-model abc1234`.
+`$ gto register awesome-model abc1234`.
 
 </details>
 
 ### Assigning a stage to version
 
 To assign an actionable stage for a specific artifact version use the same
-`gto tag` command. Stages can mark the artifact readiness for a specific
+`gto assign` command. Stages can mark the artifact readiness for a specific
 consumer. You can plug in a real downsteam system via CI/CD or web hooks, e.g.
 to redeploy an ML model.
 
 ```console
-$ gto tag awesome-model --version v0.0.1 --stage prod
+$ gto assign awesome-model v0.0.1 prod
 Created git tag 'awesome-model#prod#1' that assigns a stage to 'v0.0.1'
 ```
 
@@ -148,10 +148,10 @@ GTO the artifact file is committed to Git.
 
 Sometimes you need to mark an artifact version no longer ready for a specific
 consumer, and maybe signal a downstream system about this. You can use
-`gto untag` for that:
+`gto deprecate` for that:
 
 ```console
-$ gto untag awesome-model --version v0.0.1 --stage prod
+$ gto deprecate awesome-model v0.0.1 prod
 Created git tag 'awesome-model#prod#2!' that unassigns a stage from 'v0.0.1'
 ```
 
@@ -161,7 +161,7 @@ GTO creates a special Git tag in a standard format:
 `{artifact_name}#{stage}#{e}!`.
 
 Note, that later you can create this stage again, if you need to, by calling
-`$ gto tag` again.
+`$ gto assign` again.
 
 You also may want to delete the git tag instead of creating a new one. This is
 useful if you don't want to keep extra tags in you Git repo, don't need history
@@ -169,7 +169,7 @@ and don't want to trigger a CI/CD or another downstream system. For that, you
 can use:
 
 ```console
-$ gto untag awesome-model --version v0.0.1 --stage prod --delete
+$ gto deprecate awesome-model v0.0.1 prod --delete
 Deleted git tag 'awesome-model#prod#1' that assigned a stage to 'v0.0.1'
 To push the changes upstream, run:
 git push origin awesome-model#prod#1 --delete
@@ -181,10 +181,10 @@ git push origin awesome-model#prod#1 --delete
 
 Sometimes you need mark a specific artifact version as a no longer ready for
 usage. You could just delete a git tag, but if you want to preserve a history of
-the actions, you may find `gto untag` useful.
+the actions, you may again use `gto deprecate`.
 
 ```console
-$ gto untag awesome-model --version v0.0.1
+$ gto deprecate awesome-model v0.0.1
 Created git tag 'awesome-model@v0.0.1!' that deregistered a version.
 ```
 
@@ -194,7 +194,7 @@ If you want to deregister the version by deleting the Git tags itself, you could
 use
 
 ```console
-$ gto untag awesome-model --version v0.0.1 --delete
+$ gto deprecate awesome-model v0.0.1 --delete
 Deleted git tag 'awesome-model@v0.0.1' that registered a version.
 Deleted git tag 'awesome-model#prod#1' that assigned a stage to 'v0.0.1'.
 Deleted git tag 'awesome-model#prod#2!' that unassigned a stage to 'v0.0.1'.

--- a/README.md
+++ b/README.md
@@ -43,7 +43,38 @@ $ git clone https://github.com/iterative/example-gto.git
 $ cd example-gto
 ```
 
-### Versioning
+This guide will walk you through the Lifecycle of an artifact. To execute each
+step, you'll need to create a Git tag of a special format, which will trigger CI
+and trigger the job you intend to run:
+
+1. Registering it - marking the very beginning of the artifact history in the
+   Git repository.
+2. Publishing a version - marking an important change in the artifact.
+3. Assigning a stage to a version - marking the readiness to be consumed by a
+   downstream system.
+4. Unassigning a stage - removing an "artifact is ready for this stage" mark.
+5. Deprecating a version - marking a version as the one that should not be used
+   any longer.
+6. Deregistering an artifact - completing the lifecycle of an artifact and
+   marking it as an outdated one.
+
+### Registering an artifact
+
+Note: this is an optional operation, since publishing the very first version
+with `$ gto publish` already implies registering the artifact.
+
+To start tracking the artifact in the registry, you need to run:
+
+```console
+$ gto register awesome-model
+Created Git tag `awesome-model@` that registers the artifact.
+```
+
+This can be done to mark the very beginning of the artifact history, so it's
+better to create this tag for the very first commit the artifact was present in
+(even not annotated - see below what an annotation is).
+
+### Versioning an artifact
 
 To release a new artifact or a new version, use `gto publish`. This is usually
 done to mark significant changes to the artifact (such as a release).
@@ -230,19 +261,6 @@ git push origin awesome-model@v0.0.1 awesome-model#prod#1 awesome-model#prod#2! 
 
 It looks just the same as `$ gto deprecate awesome-model --delete`, but will
 include all artifact versions that exist.
-
-One more thing: since there is a `$ gto deregister`, there should be the command
-that does the opposite. It's `$ gto register`:
-
-```console
-$ gto register awesome-model
-Created Git tag `awesome-model@` that registers the artifact.
-```
-
-This can be done to undo `deregister` and keep the history or at the very
-beginning to add the artifact to the artifact registry. Although, in the last
-it's not mandatory since publishing the very first version with `$ gto publish`
-already implies registering the artifact.
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ artifact. To release a new version (including the very first one), use
 
 ```console
 $ gto tag awesome-model --version v0.0.1
-Created git tag 'awesome-model@v0.0.1'
+Created git tag 'awesome-model@v0.0.1' that registers a version
 ```
 
 <details summary="What happens under the hood?">
@@ -65,7 +65,7 @@ another Git commit if you provide it's hexsha as an additional argument, like
 
 </details>
 
-### Assigning a stage
+### Assigning a stage to version
 
 To assign an actionable stage for a specific artifact version use the same
 `gto tag` command. Stages can mark the artifact readiness for a specific
@@ -74,7 +74,7 @@ to redeploy an ML model.
 
 ```console
 $ gto tag awesome-model --version v0.0.1 --stage prod
-Created git tag 'awesome-model#prod#1'
+Created git tag 'awesome-model#prod#1' that assigns a stage to 'v0.0.1'
 ```
 
 <details summary="What happens under the hood?">
@@ -152,7 +152,7 @@ consumer, and maybe signal a downstream system about this. You can use
 
 ```console
 $ gto untag awesome-model --version v0.0.1 --stage prod
-Created git tag 'awesome-model#prod#2!'
+Created git tag 'awesome-model#prod#2!' that unassigns a stage from 'v0.0.1'
 ```
 
 <details summary="Some details and options">
@@ -170,7 +170,7 @@ can use:
 
 ```console
 $ gto untag awesome-model --version v0.0.1 --stage prod --delete
-Deleted git tag 'awesome-model#prod#1'
+Deleted git tag 'awesome-model#prod#1' that assigned a stage to 'v0.0.1'
 To push the changes upstream, run:
 git push origin awesome-model#prod#1 --delete
 ```
@@ -196,11 +196,14 @@ use
 ```console
 $ gto untag awesome-model --version v0.0.1 --delete
 Deleted git tag 'awesome-model@v0.0.1' that registered a version.
-Deleted git tag 'awesome-model#prod#1' that assigned a stage.
-Deleted git tag 'awesome-model#prod#2!' that unassigned a stage.
+Deleted git tag 'awesome-model#prod#1' that assigned a stage to 'v0.0.1'.
+Deleted git tag 'awesome-model#prod#2!' that unassigned a stage to 'v0.0.1'.
 To push the changes upstream, run:
 git push origin awesome-model@v0.0.1 awesome-model#prod#1 awesome-model#prod#2! --delete
 ```
+
+This includes all Git tags related to the version: a tag that registered it and
+all tags that assigned stages to it.
 
 </details>
 
@@ -225,12 +228,11 @@ all of them for the artifact. You could do that with
 
 ```console
 $ gto deprecate awesome-model --delete
-Deleted git tag 'awesome-model@registered' that registered an artifact.
 Deleted git tag 'awesome-model@v0.0.1' that registered a version.
-Deleted git tag 'awesome-model#prod#1' that assigned a stage.
-Deleted git tag 'awesome-model#prod#2!' that unassigned a stage.
+Deleted git tag 'awesome-model#prod#1' that assigned a stage to 'v0.0.1'.
+Deleted git tag 'awesome-model#prod#2!' that unassigned a stage to 'v0.0.1'.
 To push the changes upstream, run:
-git push origin awesome-model@registered awesome-model@v0.0.1 awesome-model#prod#1 awesome-model#prod#2! --delete
+git push origin awesome-model@v0.0.1 awesome-model#prod#1 awesome-model#prod#2! --delete
 ```
 
 </details>

--- a/README.md
+++ b/README.md
@@ -128,9 +128,9 @@ git push origin awesome-model#prod#1 --delete
 
 ### Annotating
 
-So far we've seen how to publish and assign a stage to an artifact versions,
-but we still don't have much information about them. What about the type of
-artifact (dataset, model, etc.) or the file path to find it in the working tree?
+So far we've seen how to publish and assign a stage to an artifact versions, but
+we still don't have much information about them. What about the type of artifact
+(dataset, model, etc.) or the file path to find it in the working tree?
 
 For simple projects (e.g. single artifact) we can assume the details in a
 downstream system. But for more advanced cases, we should codify them in the
@@ -211,6 +211,7 @@ it's outdated and will no longer be developed. To do this, you could run:
 
 ```console
 $ gto deregister awesome-model
+Created Git tag 'awesome-model@!' that deregisters the artifact.
 ```
 
 <details summary="Some details and options">
@@ -229,6 +230,19 @@ git push origin awesome-model@v0.0.1 awesome-model#prod#1 awesome-model#prod#2! 
 
 It looks just the same as `$ gto deprecate awesome-model --delete`, but will
 include all artifact versions that exist.
+
+One more thing: since there is a `$ gto deregister`, there should be the command
+that does the opposite. It's `$ gto register`:
+
+```console
+$ gto register awesome-model
+Created Git tag `awesome-model@` that registers the artifact.
+```
+
+This can be done to undo `deregister` and keep the history or at the very
+beginning to add the artifact to the artifact registry. Although, in the last
+it's not mandatory since publishing the very first version with `$ gto publish`
+already implies registering the artifact.
 
 </details>
 
@@ -269,7 +283,9 @@ $ gto show churn
 ╘════════════╧═══════════╧══════════════╧═════════════════════╧══════════════╛
 ```
 
-<details summary="#### Enabling multiple versions in the same Stage workflow">
+#### Enabling multiple versions in the same Stage workflow
+
+<details summary="Details">
 
 Note: this functionality is experimental and subject to change. If you find it
 useful, please share your feedback in GH issues to help us make it stable.
@@ -294,7 +310,9 @@ approach you choose.
 
 </details>
 
-<details summary="#### Enabling Kanban workflow">
+#### Enabling Kanban workflow
+
+<details summary="Details">
 
 Note: this functionality is experimental and subject to change. If you find it
 useful, please share your feedback in GH issues to help us make it stable.

--- a/README.md
+++ b/README.md
@@ -178,15 +178,18 @@ GTO the artifact file is committed to Git.
 
 ### Deprecating
 
-Sometimes you need to need to mark the artifact as "deprecated", usually meaning it's outdated and will no longer be developed. To do this, you could run:
+Sometimes you need to need to mark the artifact as "deprecated", usually meaning
+it's outdated and will no longer be developed. To do this, you could run:
 
 ```console
 $ gto deprecate awesome-model
 ```
 
 Generally, the artifact is considered to be deprecated either if
+
 1. There is a `awesome-model@deprecated` git tag
-2. There are no git tags for the artifact and it doesn't appear in `artifacts.yaml` in the workspace (i.e. in the check outed commit).
+2. There are no git tags for the artifact and it doesn't appear in
+   `artifacts.yaml` in the workspace (i.e. in the check outed commit).
 
 ### Removing
 
@@ -206,7 +209,7 @@ $ gto show
 ╒═══════════════╤══════════╤════════╤═════════╤════════════╕
 │ name          │ latest   │ #dev   │ #prod   │ #staging   │
 ╞═══════════════╪══════════╪════════╪═════════╪════════════╡
-│ churn         │ v3.1.0   │ v3.0.0 │ v3.0.0  │ v3.1.0     │
+│ churn         │ v3.1.0   │ v3.1.0 │ v3.0.0  │ v3.1.0     │
 │ segment       │ v0.4.1   │ v0.4.1 │ -       │ -          │
 │ cv-class      │ v0.1.13  │ -      │ -       │ -          │
 │ awesome-model │ v0.0.1   │ -      │ v0.0.1  │ -          │
@@ -221,15 +224,41 @@ Add an artifact name to print all of its versions instead:
 
 ```console
 $ gto show churn
-╒════════════╤═══════════╤═══════════╤═════════════════════╤═══════════════════╤══════════════╕
-│ artifact   │ version   │ stage     │ created_at          │ author            │ ref          │
-╞════════════╪═══════════╪═══════════╪═════════════════════╪═══════════════════╪══════════════╡
-│ churn      │ v3.1.0    │ staging   │ 2022-07-13 15:25:41 │ Alexander Guschin │ churn@v3.1.0 │
-│ churn      │ v3.0.0    │ prod, dev │ 2022-07-09 00:19:01 │ Alexander Guschin │ churn@v3.0.0 │
-╘════════════╧═══════════╧═══════════╧═════════════════════╧═══════════════════╧══════════════╛
+╒════════════╤═══════════╤══════════════╤═════════════════════╤══════════════╕
+│ artifact   │ version   │ stage        │ created_at          │ ref          │
+╞════════════╪═══════════╪══════════════╪═════════════════════╪══════════════╡
+│ churn      │ v3.1.0    │ staging, dev │ 2022-07-14 10:33:53 │ churn@v3.1.0 │
+│ churn      │ v3.0.0    │ prod         │ 2022-07-09 19:27:13 │ churn@v3.0.0 │
+╘════════════╧═══════════╧══════════════╧═════════════════════╧══════════════╛
 ```
 
+#### Enabling multiple versions in the same Stage workflow
+
+Note: this functionality is experimental and subject to change. If you find it
+useful, please share your feedback in GH issues to help us make it stable.
+
+In some cases, you want to see more than a single version assigned in a stage.
+For that, use `--lv` (short for `--last-assignments-per-version`), e.g. `-1` to
+show all versions.
+
+```console
+$ gto show churn --lv -1
+╒════════════╤═══════════╤══════════════╤═════════════════════╤══════════════╕
+│ artifact   │ version   │ stage        │ created_at          │ ref          │
+╞════════════╪═══════════╪══════════════╪═════════════════════╪══════════════╡
+│ churn      │ v3.1.0    │ staging, dev │ 2022-07-14 10:33:53 │ churn@v3.1.0 │
+│ churn      │ v3.0.0    │ dev, prod    │ 2022-07-09 19:27:13 │ churn@v3.0.0 │
+╘════════════╧═══════════╧══════════════╧═════════════════════╧══════════════╛
+```
+
+To enable this workflow, you need to supply the `--lv` argument to `gto show`
+and `gto which` commands. Other commands behave the same way regardless of the
+approach you choose.
+
 #### Enabling Kanban workflow
+
+Note: this functionality is experimental and subject to change. If you find it
+useful, please share your feedback in GH issues to help us make it stable.
 
 In some cases, you would like to have a latest stage for an artifact version to
 replace all the previous stages. In this case the version will have a single
@@ -237,19 +266,22 @@ stage. This resembles Kanban workflow, when you "move" your artifact version
 from one column ("stage-1") to another ("stage-2"). This is how MLFlow and some
 other Model Registries work.
 
-To achieve this, you can use `--last-stage` flag (or `--ls` for short):
+To achieve this, you can use `--la` flag (or `--last-versions-per-stage` for
+short) combined with `--lv`:
 
 ```console
-$ gto show --ls
-╒═══════════════╤══════════╤════════╤═════════╤════════════╕
-│ name          │ latest   │ #dev   │ #prod   │ #staging   │
-╞═══════════════╪══════════╪════════╪═════════╪════════════╡
-│ churn         │ v3.1.0   │ -      │ v3.0.0  │ v3.1.0     │
-│ segment       │ v0.4.1   │ v0.4.1 │ -       │ -          │
-│ cv-class      │ v0.1.13  │ -      │ -       │ -          │
-│ awesome-model │ v0.0.1   │ -      │ v0.0.1  │ -          │
-╘═══════════════╧══════════╧════════╧═════════╧════════════╛
+$ gto show churn --la 1 --lv -1
+╒════════════╤═══════════╤═════════╤═════════════════════╤══════════════╕
+│ artifact   │ version   │ stage   │ created_at          │ ref          │
+╞════════════╪═══════════╪═════════╪═════════════════════╪══════════════╡
+│ churn      │ v3.1.0    │ staging │ 2022-07-14 10:33:53 │ churn@v3.1.0 │
+│ churn      │ v3.0.0    │ dev     │ 2022-07-09 19:27:13 │ churn@v3.0.0 │
+╘════════════╧═══════════╧═════════╧═════════════════════╧══════════════╛
 ```
+
+To enable this workflow, you need to supply the `--lv` argument to `gto show`
+and `gto which` commands. Other commands behave the same way regardless of the
+approach you choose.
 
 ### See the history of an artifact
 
@@ -258,17 +290,19 @@ This allows you to audit the changes.
 
 ```console
 $ gto history churn
-╒═════════════════════╤════════════╤══════════════╤═══════════╤═════════╤══════════╤═══════════════════╕
-│ timestamp           │ artifact   │ event        │ version   │ stage   │ commit   │ author            │
-╞═════════════════════╪════════════╪══════════════╪═══════════╪═════════╪══════════╪═══════════════════╡
-│ 2022-07-17 02:45:41 │ churn      │ assignment    │ v3.0.0    │ prod    │ 631520b  │ Alexander Guschin │
-│ 2022-07-15 22:59:01 │ churn      │ assignment    │ v3.1.0    │ staging │ be340cc  │ Alexander Guschin │
-│ 2022-07-14 19:12:21 │ churn      │ assignment    │ v3.0.0    │ dev     │ 631520b  │ Alexander Guschin │
-│ 2022-07-13 15:25:41 │ churn      │ registration │ v3.1.0    │ -       │ be340cc  │ Alexander Guschin │
-│ 2022-07-12 11:39:01 │ churn      │ commit       │ -         │ -       │ be340cc  │ Alexander Guschin │
-│ 2022-07-09 00:19:01 │ churn      │ registration │ v3.0.0    │ -       │ 631520b  │ Alexander Guschin │
-│ 2022-07-07 20:32:21 │ churn      │ commit       │ -         │ -       │ 631520b  │ Alexander Guschin │
-╘═════════════════════╧════════════╧══════════════╧═══════════╧═════════╧══════════╧═══════════════════╛
+╒═════════════════════╤════════════╤══════════════╤═══════════╤═════════╤══════════╤═════════════════╕
+│ timestamp           │ artifact   │ event        │ version   │ stage   │ commit   │ ref             │
+╞═════════════════════╪════════════╪══════════════╪═══════════╪═════════╪══════════╪═════════════════╡
+│ 2022-07-29 14:50:10 │ churn      │ assignment   │ v3.1.0    │ dev     │ 8e4b8e9  │ churn#dev#4     │
+│ 2022-07-17 21:53:53 │ churn      │ assignment   │ v3.0.0    │ prod    │ 0d4e471  │ churn#prod#3    │
+│ 2022-07-16 18:07:13 │ churn      │ assignment   │ v3.1.0    │ staging │ 8e4b8e9  │ churn#staging#2 │
+│ 2022-07-15 14:20:33 │ churn      │ assignment   │ v3.0.0    │ dev     │ 0d4e471  │ churn#dev#1     │
+│ 2022-07-14 10:33:53 │ churn      │ registration │ v3.1.0    │ -       │ 8e4b8e9  │ churn@v3.1.0    │
+│ 2022-07-13 06:47:13 │ churn      │ commit       │ v3.1.0    │ -       │ 8e4b8e9  │ 8e4b8e9         │
+│ 2022-07-13 06:47:13 │ churn      │ commit       │ v3.1.0    │ -       │ 8e4b8e9  │ 8e4b8e9         │
+│ 2022-07-09 19:27:13 │ churn      │ registration │ v3.0.0    │ -       │ 0d4e471  │ churn@v3.0.0    │
+│ 2022-07-08 15:40:33 │ churn      │ commit       │ v3.0.0    │ -       │ 0d4e471  │ 0d4e471         │
+╘═════════════════════╧════════════╧══════════════╧═══════════╧═════════╧══════════╧═════════════════╛
 ```
 
 ## Consuming the registry downstream
@@ -332,25 +366,11 @@ To get the version that is currently assigned to an environment (stage), use
 
 ```console
 $ gto which churn dev
-v3.0.0
+v3.1.0
 
 $ gto which churn dev --ref
-churn#dev#1
+churn#dev#4
 ```
-
-<details summary="Kanban workflow">
-
-If you prefer Kanban workflow described above, you could use `--last` flag. This
-will take into account the last stage for a version only.
-
-```console
-$ gto which churn dev --last
-```
-
-Since the last stage for version `v3.0.0` was `prod`, this doesn't return
-anything.
-
-</details>
 
 To get details about an artifact (from `artifacts.yaml`) use `gto describe`:
 

--- a/README.md
+++ b/README.md
@@ -45,12 +45,12 @@ $ cd example-gto
 
 ### Versioning
 
-To register a new artifact or a new version, use `gto register`. This is usually
+To release a new artifact or a new version, use `gto publish`. This is usually
 done to mark significant changes to the artifact (such as a release).
 
 ```console
-$ gto register awesome-model
-Created git tag 'awesome-model@v0.0.1' that registers a new version
+$ gto publish awesome-model
+Created git tag 'awesome-model@v0.0.1' that publishes a new version
 ```
 
 <details summary="What happens under the hood?">
@@ -60,11 +60,11 @@ GTO creates a special Git tag for the artifact version, in a standard format:
 
 The version is now associated to the current Git commit (`HEAD`). You can use
 another Git commit if you provide it's hexsha as an additional argument, like
-`$ gto register awesome-model abc1234`.
+`$ gto publish awesome-model abc1234`.
 
 </details>
 
-### Assign a stage
+### Assigning a stage
 
 Assign an actionable stage for a specific artifact version with `gto assign`.
 Stages can mark it's readiness for a specific consumer. You can plug in a real
@@ -91,7 +91,7 @@ require deleting the existing tag.
 
 </details>
 
-### Unassign a stage
+### Unassigning a stage
 
 Note: this functionality is in development and will be introduced soon.
 
@@ -128,7 +128,7 @@ git push origin awesome-model#prod#1 --delete
 
 ### Annotating
 
-So far we've seen how to register and assign a stage to an artifact versions,
+So far we've seen how to publish and assign a stage to an artifact versions,
 but we still don't have much information about them. What about the type of
 artifact (dataset, model, etc.) or the file path to find it in the working tree?
 
@@ -158,7 +158,7 @@ GTO the artifact file is committed to Git.
 
 <details summary="Virtual vs. Physical artifacts">
 
-- Physical files/directories are committed to the repo. When you register a new
+- Physical files/directories are committed to the repo. When you publish a new
   version or assign a stage to it, Git guarantees that it's immutable -- you can
   return a year later and get the same artifact by providing a version.
 
@@ -176,16 +176,16 @@ GTO the artifact file is committed to Git.
 
 </details>
 
-### Deregistering
+### Deprecating a version
 
 Sometimes you need mark a specific artifact version as a deprecated one,
 signaling that it's not ready to be used any more. You could just delete a git
 tag, but if you want to preserve a history of the actions, you may find
-`gto deregister` useful.
+`gto deprecate` useful.
 
 ```console
-$ gto deregister awesome-model v0.0.1
-Created git tag 'awesome-model@v0.0.1!' that deregisters a version.
+$ gto deprecate awesome-model --version v0.0.1
+Created git tag 'awesome-model@v0.0.1!' that deprecates a version.
 ```
 
 <details summary="Some details and options">
@@ -194,8 +194,8 @@ If you want to deprecate the version by deleting the Git tags itself, you could
 use
 
 ```console
-$ gto deregister awesome-model v0.0.1 --delete
-Deleted git tag 'awesome-model@v0.0.1' that registered a version.
+$ gto deprecate awesome-model --version v0.0.1 --delete
+Deleted git tag 'awesome-model@v0.0.1' that published a version.
 Deleted git tag 'awesome-model#prod#1' that assigned a stage.
 Deleted git tag 'awesome-model#prod#2!' that unassigned a stage.
 To push the changes upstream, run:
@@ -204,13 +204,13 @@ git push origin awesome-model@v0.0.1 awesome-model#prod#1 awesome-model#prod#2! 
 
 </details>
 
-### Deprecating
+### Deregistering an artifact
 
 Sometimes you need to need to mark the artifact as "deprecated", usually meaning
 it's outdated and will no longer be developed. To do this, you could run:
 
 ```console
-$ gto deprecate awesome-model
+$ gto deregister awesome-model
 ```
 
 <details summary="Some details and options">
@@ -219,15 +219,15 @@ If you want to deprecate an artifact by deleting git tags, you'll need to delete
 all of them for the artifact. You could do that with
 
 ```console
-$ gto deprecate awesome-model --delete
-Deleted git tag 'awesome-model@v0.0.1' that registered a version.
+$ gto deregister awesome-model --delete
+Deleted git tag 'awesome-model@v0.0.1' that published a version.
 Deleted git tag 'awesome-model#prod#1' that assigned a stage.
 Deleted git tag 'awesome-model#prod#2!' that unassigned a stage.
 To push the changes upstream, run:
 git push origin awesome-model@v0.0.1 awesome-model#prod#1 awesome-model#prod#2! --delete
 ```
 
-It looks just the same as `$ gto register awesome-model --delete`, but will
+It looks just the same as `$ gto deprecate awesome-model --delete`, but will
 include all artifact versions that exist.
 
 </details>
@@ -269,7 +269,7 @@ $ gto show churn
 ╘════════════╧═══════════╧══════════════╧═════════════════════╧══════════════╛
 ```
 
-#### Enabling multiple versions in the same Stage workflow
+<details summary="#### Enabling multiple versions in the same Stage workflow">
 
 Note: this functionality is experimental and subject to change. If you find it
 useful, please share your feedback in GH issues to help us make it stable.
@@ -292,7 +292,9 @@ To enable this workflow, you need to supply the `--av` argument to `gto show`
 and `gto which` commands. Other commands behave the same way regardless of the
 approach you choose.
 
-#### Enabling Kanban workflow
+</details>
+
+<details summary="#### Enabling Kanban workflow">
 
 Note: this functionality is experimental and subject to change. If you find it
 useful, please share your feedback in GH issues to help us make it stable.
@@ -319,6 +321,8 @@ $ gto show churn --av 1 --vs -1
 To enable this workflow, you need to supply the `--vs` and `--av` arguments to
 `gto show` and `gto which` commands. Other commands behave the same way
 regardless of the approach you choose.
+
+</details>
 
 ### See the history of an artifact
 

--- a/README.md
+++ b/README.md
@@ -176,6 +176,22 @@ GTO the artifact file is committed to Git.
 
 </details>
 
+### Deprecating
+
+Sometimes you need to need to mark the artifact as "deprecated", usually meaning it's outdated and will no longer be developed. To do this, you could run:
+
+```console
+$ gto deprecate awesome-model
+```
+
+Generally, the artifact is considered to be deprecated either if
+1. There is a `awesome-model@deprecated` git tag
+2. There are no git tags for the artifact and it doesn't appear in `artifacts.yaml` in the workspace (i.e. in the check outed commit).
+
+### Removing
+
+TODO
+
 ## Using the registry locally
 
 Let's look at the usage of the `gto show` and `gto history`.

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ consumer. You can plug in a real downsteam system via CI/CD or web hooks, e.g.
 to redeploy an ML model.
 
 ```console
-$ gto assign awesome-model v0.0.1 prod
+$ gto assign awesome-model --version v0.0.1 --stage prod
 Created git tag 'awesome-model#prod#1' that assigns a stage to 'v0.0.1'
 ```
 

--- a/README.md
+++ b/README.md
@@ -238,11 +238,11 @@ Note: this functionality is experimental and subject to change. If you find it
 useful, please share your feedback in GH issues to help us make it stable.
 
 In some cases, you want to see more than a single version assigned in a stage.
-For that, use `--lv` (short for `--last-assignments-per-version`), e.g. `-1` to
-show all versions.
+For that, use `--av` (short for `--assignments-per-version`), e.g. `-1` to show
+all versions.
 
 ```console
-$ gto show churn --lv -1
+$ gto show churn --av -1
 ╒════════════╤═══════════╤══════════════╤═════════════════════╤══════════════╕
 │ artifact   │ version   │ stage        │ created_at          │ ref          │
 ╞════════════╪═══════════╪══════════════╪═════════════════════╪══════════════╡
@@ -251,7 +251,7 @@ $ gto show churn --lv -1
 ╘════════════╧═══════════╧══════════════╧═════════════════════╧══════════════╛
 ```
 
-To enable this workflow, you need to supply the `--lv` argument to `gto show`
+To enable this workflow, you need to supply the `--av` argument to `gto show`
 and `gto which` commands. Other commands behave the same way regardless of the
 approach you choose.
 
@@ -266,11 +266,11 @@ stage. This resembles Kanban workflow, when you "move" your artifact version
 from one column ("stage-1") to another ("stage-2"). This is how MLFlow and some
 other Model Registries work.
 
-To achieve this, you can use `--la` flag (or `--last-versions-per-stage` for
-short) combined with `--lv`:
+To achieve this, you can use `--vs` flag (or `--versions-per-stage` for short)
+combined with `--av`:
 
 ```console
-$ gto show churn --la 1 --lv -1
+$ gto show churn --av 1 --vs -1
 ╒════════════╤═══════════╤═════════╤═════════════════════╤══════════════╕
 │ artifact   │ version   │ stage   │ created_at          │ ref          │
 ╞════════════╪═══════════╪═════════╪═════════════════════╪══════════════╡
@@ -279,9 +279,9 @@ $ gto show churn --la 1 --lv -1
 ╘════════════╧═══════════╧═════════╧═════════════════════╧══════════════╛
 ```
 
-To enable this workflow, you need to supply the `--lv` argument to `gto show`
-and `gto which` commands. Other commands behave the same way regardless of the
-approach you choose.
+To enable this workflow, you need to supply the `--vs` and `--av` arguments to
+`gto show` and `gto which` commands. Other commands behave the same way
+regardless of the approach you choose.
 
 ### See the history of an artifact
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,8 @@ and trigger the job you intend to run:
 ### Registering an artifact
 
 Note: this is an optional operation, since publishing the very first version
-with `$ gto publish` already implies registering the artifact.
+with `$ gto publish` or annotating it with `$ gto annotate` in the `HEAD` of any
+branch already implies that artifact is registered.
 
 To start tracking the artifact in the registry, you need to run:
 
@@ -260,7 +261,8 @@ git push origin awesome-model@v0.0.1 awesome-model#prod#1 awesome-model#prod#2! 
 ```
 
 It looks just the same as `$ gto deprecate awesome-model --delete`, but will
-include all artifact versions that exist.
+include tags for all artifact versions that exist, as well as a creation tag if
+it existed.
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ To start tracking the artifact in the registry, you need to run:
 
 ```console
 $ gto register awesome-model
-Created Git tag `awesome-model@` that registers the artifact.
+Created Git tag 'awesome-model@registered' that registers the artifact.
 ```
 
 This can be done to mark the very beginning of the artifact history, so it's
@@ -243,7 +243,7 @@ it's outdated and will no longer be developed. To do this, you could run:
 
 ```console
 $ gto deregister awesome-model
-Created Git tag 'awesome-model@!' that deregisters the artifact.
+Created Git tag 'awesome-model@deregistered' that deregisters the artifact.
 ```
 
 <details summary="Some details and options">
@@ -253,16 +253,13 @@ all of them for the artifact. You could do that with
 
 ```console
 $ gto deregister awesome-model --delete
+Deleted git tag 'awesome-model@registered' that registered an artifact.
 Deleted git tag 'awesome-model@v0.0.1' that published a version.
 Deleted git tag 'awesome-model#prod#1' that assigned a stage.
 Deleted git tag 'awesome-model#prod#2!' that unassigned a stage.
 To push the changes upstream, run:
-git push origin awesome-model@v0.0.1 awesome-model#prod#1 awesome-model#prod#2! --delete
+git push origin awesome-model@registered awesome-model@v0.0.1 awesome-model#prod#1 awesome-model#prod#2! --delete
 ```
-
-It looks just the same as `$ gto deprecate awesome-model --delete`, but will
-include tags for all artifact versions that exist, as well as a creation tag if
-it existed.
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -64,9 +64,9 @@ several versions in a given commit, ordered by their automatic version numbers.
 
 </details>
 
-### Assing a stage
+### Assign a stage
 
-Assing an actionable stage for a specific artifact version with `gto assign`.
+Assign an actionable stage for a specific artifact version with `gto assign`.
 Stages can mark it's readiness for a specific consumer. You can plug in a real
 downsteam system via CI/CD or web hooks. For example: redeploy an ML model.
 

--- a/README.md
+++ b/README.md
@@ -46,8 +46,7 @@ $ cd example-gto
 ### Versioning
 
 To register a new artifact or a new version, use `gto register`. This is usually
-done to mark significant changes to the artifact (such as a release or a
-deprecation).
+done to mark significant changes to the artifact (such as a release).
 
 ```console
 $ gto register awesome-model
@@ -59,8 +58,9 @@ Created git tag 'awesome-model@v0.0.1' that registers a new version
 GTO creates a special Git tag for the artifact version, in a standard format:
 `{artifact_name}@{version_number}`.
 
-The version is now associated to the current Git commit (`HEAD`). You can have
-several versions in a given commit, ordered by their automatic version numbers.
+The version is now associated to the current Git commit (`HEAD`). You can use
+another Git commit if you provide it's hexsha as an additional argument, like
+`$ gto register awesome-model abc1234`.
 
 </details>
 
@@ -120,7 +120,7 @@ can use:
 ```console
 $ gto unassign --delete
 Deleted git tag 'awesome-model#prod#1' that assigned 'prod' to 'v0.0.1'
-To push the changes upsteam, run:
+To push the changes upstream, run:
 git push origin awesome-model#prod#1 --delete
 ```
 
@@ -176,6 +176,34 @@ GTO the artifact file is committed to Git.
 
 </details>
 
+### Deregistering
+
+Sometimes you need mark a specific artifact version as a deprecated one,
+signaling that it's not ready to be used any more. You could just delete a git
+tag, but if you want to preserve a history of the actions, you may find
+`gto deregister` useful.
+
+```console
+$ gto deregister awesome-model v0.0.1
+Created git tag 'awesome-model@v0.0.1!' that deregisters a version.
+```
+
+<details summary="Some details and options">
+
+If you want to deprecate the version by deleting the Git tags itself, you could
+use
+
+```console
+$ gto deregister awesome-model v0.0.1 --delete
+Deleted git tag 'awesome-model@v0.0.1' that registered a version.
+Deleted git tag 'awesome-model#prod#1' that assigned a stage.
+Deleted git tag 'awesome-model#prod#2!' that unassigned a stage.
+To push the changes upstream, run:
+git push origin awesome-model@v0.0.1 awesome-model#prod#1 awesome-model#prod#2! --delete
+```
+
+</details>
+
 ### Deprecating
 
 Sometimes you need to need to mark the artifact as "deprecated", usually meaning
@@ -185,15 +213,24 @@ it's outdated and will no longer be developed. To do this, you could run:
 $ gto deprecate awesome-model
 ```
 
-Generally, the artifact is considered to be deprecated either if
+<details summary="Some details and options">
 
-1. There is a `awesome-model@deprecated` git tag
-2. There are no git tags for the artifact and it doesn't appear in
-   `artifacts.yaml` in the workspace (i.e. in the check outed commit).
+If you want to deprecate an artifact by deleting git tags, you'll need to delete
+all of them for the artifact. You could do that with
 
-### Removing
+```console
+$ gto deprecate awesome-model --delete
+Deleted git tag 'awesome-model@v0.0.1' that registered a version.
+Deleted git tag 'awesome-model#prod#1' that assigned a stage.
+Deleted git tag 'awesome-model#prod#2!' that unassigned a stage.
+To push the changes upstream, run:
+git push origin awesome-model@v0.0.1 awesome-model#prod#1 awesome-model#prod#2! --delete
+```
 
-TODO
+It looks just the same as `$ gto register awesome-model --delete`, but will
+include all artifact versions that exist.
+
+</details>
 
 ## Using the registry locally
 

--- a/gto/api.py
+++ b/gto/api.py
@@ -117,10 +117,10 @@ def assign(
     repo: Union[str, Repo],
     name: str,
     stage: str,
-    version: str = None,
-    ref: str = None,
-    name_version: str = None,
-    message: str = None,
+    version: Optional[str] = None,
+    ref: Optional[str] = None,
+    name_version: Optional[str] = None,
+    message: Optional[str] = None,
     simple: bool = False,
     force: bool = False,
     skip_registration: bool = False,
@@ -145,9 +145,10 @@ def assign(
     )
 
 
-def deprecate(
+def unassign(
     repo: Union[str, Repo],
     name: str,
+    ref: str = None,
     version: str = None,
     stage: str = None,
     message: str = None,
@@ -158,31 +159,59 @@ def deprecate(
     author: Optional[str] = None,
     author_email: Optional[str] = None,
 ):
-    if stage:
-        return GitRegistry.from_repo(repo).unassign(
-            name=name,
-            stage=stage,
-            version=version,
-            message=message,
-            stdout=stdout,
-            simple=simple if simple is not None else False,
-            force=force,
-            delete=delete,
-            author=author,
-            author_email=author_email,
-        )
-    if version:
-        return GitRegistry.from_repo(repo).deregister(
-            name=name,
-            version=version,
-            message=message,
-            stdout=stdout,
-            simple=simple if simple is not None else True,
-            force=force,
-            delete=delete,
-            author=author,
-            author_email=author_email,
-        )
+    return GitRegistry.from_repo(repo).unassign(
+        name=name,
+        stage=stage,
+        ref=ref,
+        version=version,
+        message=message,
+        stdout=stdout,
+        simple=simple if simple is not None else False,
+        force=force,
+        delete=delete,
+        author=author,
+        author_email=author_email,
+    )
+
+
+def deregister(
+    repo: Union[str, Repo],
+    name: str,
+    ref: str = None,
+    version: str = None,
+    message: str = None,
+    stdout: bool = False,
+    simple: Optional[bool] = None,
+    force: bool = False,
+    delete: bool = False,
+    author: Optional[str] = None,
+    author_email: Optional[str] = None,
+):
+    return GitRegistry.from_repo(repo).deregister(
+        name=name,
+        ref=ref,
+        version=version,
+        message=message,
+        stdout=stdout,
+        simple=simple if simple is not None else True,
+        force=force,
+        delete=delete,
+        author=author,
+        author_email=author_email,
+    )
+
+
+def deprecate(
+    repo: Union[str, Repo],
+    name: str,
+    message: str = None,
+    stdout: bool = False,
+    simple: Optional[bool] = None,
+    force: bool = False,
+    delete: bool = False,
+    author: Optional[str] = None,
+    author_email: Optional[str] = None,
+):
     return GitRegistry.from_repo(repo).deprecate(
         name=name,
         message=message,

--- a/gto/api.py
+++ b/gto/api.py
@@ -174,7 +174,7 @@ def unassign(
     )
 
 
-def deregister(
+def unregister(
     repo: Union[str, Repo],
     name: str,
     ref: str = None,
@@ -187,7 +187,7 @@ def deregister(
     author: Optional[str] = None,
     author_email: Optional[str] = None,
 ):
-    return GitRegistry.from_repo(repo).deregister(
+    return GitRegistry.from_repo(repo).unregister(
         name=name,
         ref=ref,
         version=version,

--- a/gto/api.py
+++ b/gto/api.py
@@ -2,9 +2,10 @@ from collections import OrderedDict
 from datetime import datetime
 from typing import List, Optional, Union
 
+from funcy import distinct
 from git import Repo
 
-from gto.constants import NAME, STAGE, VERSION
+from gto.constants import NAME, STAGE, VERSION, Event
 from gto.exceptions import NoRepo, WrongArgs
 from gto.ext import EnrichmentInfo
 from gto.index import (
@@ -101,12 +102,12 @@ def register(
     )
 
 
-def promote(
+def assign(
     repo: Union[str, Repo],
     name: str,
     stage: str,
-    promote_version: str = None,
-    promote_ref: str = None,
+    version: str = None,
+    ref: str = None,
     name_version: str = None,
     message: str = None,
     simple: bool = False,
@@ -117,11 +118,11 @@ def promote(
     author_email: Optional[str] = None,
 ):
     """Assign stage to specific artifact version"""
-    return GitRegistry.from_repo(repo).promote(
+    return GitRegistry.from_repo(repo).assign(
         name,
         stage,
-        promote_version,
-        promote_ref,
+        version,
+        ref,
         name_version,
         message=message,
         simple=simple,
@@ -161,7 +162,7 @@ def find_versions_in_stage(
 
 
 def check_ref(repo: Union[str, Repo], ref: str):
-    """Find out what have been registered/promoted in the provided ref"""
+    """Find out what have been registered/assigned in the provided ref"""
     reg = GitRegistry.from_repo(repo)
     return reg.check_ref(ref)
 
@@ -169,11 +170,12 @@ def check_ref(repo: Union[str, Repo], ref: str):
 def show(
     repo: Union[str, Repo],
     name: Optional[str] = None,
-    table: bool = False,
     all_branches=False,
     all_commits=False,
     truncate_hexsha=False,
     registered_only=False,
+    last_stage=False,
+    table: bool = False,
 ):
     return (
         _show_versions(
@@ -182,6 +184,7 @@ def show(
             all_branches=all_branches,
             all_commits=all_commits,
             registered_only=registered_only,
+            last_stage=last_stage,
             table=table,
             truncate_hexsha=truncate_hexsha,
         )
@@ -191,6 +194,7 @@ def show(
             all_branches=all_branches,
             all_commits=all_commits,
             registered_only=registered_only,
+            last_stage=last_stage,
             table=table,
             truncate_hexsha=truncate_hexsha,
         )
@@ -202,8 +206,9 @@ def _show_registry(
     all_branches=False,
     all_commits=False,
     registered_only=False,
+    last_stage: bool = False,
     table: bool = False,
-    truncate_hexsha: bool = False,  # pylint: disable=unused-argument
+    truncate_hexsha: bool = False,
 ):
     """Show current registry state"""
 
@@ -219,9 +224,14 @@ def _show_registry(
             else None,
             "stage": {
                 name: format_hexsha(
-                    o.get_promotions(registered_only=registered_only)[name].version
+                    o.get_assignments(
+                        registered_only=registered_only, last_stage=last_stage
+                    )[name][0].version
                 )
-                if name in o.get_promotions(registered_only=registered_only)
+                if name
+                in o.get_assignments(
+                    registered_only=registered_only, last_stage=last_stage
+                )
                 else None
                 for name in stages
             },
@@ -242,13 +252,14 @@ def _show_registry(
     return result, headers
 
 
-def _show_versions(
+def _show_versions(  # pylint: disable=too-many-locals
     repo: Union[str, Repo],
     name: str,
     raw: bool = False,
     all_branches=False,
     all_commits=False,
     registered_only=False,
+    last_stage: bool = False,
     table: bool = False,
     truncate_hexsha: bool = False,
 ):
@@ -277,8 +288,14 @@ def _show_versions(
     versions_ = []
     for v in versions:
         v["version"] = format_hexsha(v["name"])
-        if v["stage"]:
-            v["stage"] = v["stage"]["stage"]
+        v["stage"] = ", ".join(
+            distinct(
+                s["stage"]
+                for s in (
+                    v["assignments"][::-1][:1] if last_stage else v["assignments"][::-1]
+                )
+            )
+        )
         v["commit_hexsha"] = format_hexsha(v["commit_hexsha"])
         v["ref"] = v["tag"] or v["commit_hexsha"]
         for key in (
@@ -289,6 +306,7 @@ def _show_versions(
             "name",
             "message",
             "author_email",
+            "assignments",
         ):
             v.pop(key)
         # v["enrichments"] = [e["source"] for e in v["enrichments"]]
@@ -340,7 +358,7 @@ def history(  # pylint: disable=too-many-locals
                 reg.repo.commit(v.commit_hexsha).committed_date
             ),
             artifact=o.name,
-            event="commit",
+            event=Event.COMMIT,
             commit=format_hexsha(v.commit_hexsha),
             author=reg.repo.commit(v.commit_hexsha).author.name,
             author_email=reg.repo.commit(v.commit_hexsha).author.email,
@@ -354,7 +372,7 @@ def history(  # pylint: disable=too-many-locals
         OrderedDict(
             timestamp=v.created_at,
             artifact=o.name,
-            event="registration",
+            event=Event.REGISTRATION,
             version=format_hexsha(v.name),
             commit=format_hexsha(v.commit_hexsha),
             author=v.author,
@@ -366,11 +384,11 @@ def history(  # pylint: disable=too-many-locals
         for v in o.get_versions()
     ]
 
-    promotion = [
+    assignment = [
         OrderedDict(
             timestamp=p.created_at,
             artifact=o.name,
-            event="promotion",
+            event=Event.ASSIGNMENT,
             version=format_hexsha(p.version),
             stage=p.stage,
             commit=format_hexsha(p.commit_hexsha),
@@ -383,12 +401,12 @@ def history(  # pylint: disable=too-many-locals
     ]
 
     events_order = {
-        "commit": 1,
-        "registration": 2,
-        "promotion": 3,
+        Event.COMMIT: 1,
+        Event.REGISTRATION: 2,
+        Event.ASSIGNMENT: 3,
     }
     events = sorted(
-        commits + registration + promotion,
+        commits + registration + assignment,
         key=lambda x: (x["timestamp"], events_order[x["event"]]),
     )
     if not ascending:

--- a/gto/api.py
+++ b/gto/api.py
@@ -321,6 +321,7 @@ def _show_registry(
                 in o.get_vstages(
                     registered_only=registered_only,
                     assignments_per_version=assignments_per_version,
+                    versions_per_stage=versions_per_stage,
                 )
                 else None
                 for name in stages

--- a/gto/api.py
+++ b/gto/api.py
@@ -1,3 +1,4 @@
+import warnings
 from collections import OrderedDict
 from datetime import datetime
 from typing import List, Optional, Union
@@ -102,6 +103,42 @@ def register(
     )
 
 
+def promote(
+    repo: Union[str, Repo],
+    name: str,
+    stage: str,
+    promote_version: str = None,
+    promote_ref: str = None,
+    name_version: str = None,
+    message: str = None,
+    simple: bool = False,
+    force: bool = False,
+    skip_registration: bool = False,
+    stdout: bool = False,
+    author: Optional[str] = None,
+    author_email: Optional[str] = None,
+):
+    """Assign stage to specific artifact version"""
+    warnings.warn(
+        "`gto.api.promote` is deprecated and will be removed in future releases.",
+        category=DeprecationWarning,
+    )
+    return GitRegistry.from_repo(repo).assign(
+        name,
+        stage,
+        promote_version,
+        promote_ref,
+        name_version,
+        message=message,
+        simple=simple,
+        force=force,
+        skip_registration=skip_registration,
+        stdout=stdout,
+        author=author,
+        author_email=author_email,
+    )
+
+
 def assign(
     repo: Union[str, Repo],
     name: str,
@@ -128,6 +165,36 @@ def assign(
         simple=simple,
         force=force,
         skip_registration=skip_registration,
+        stdout=stdout,
+        author=author,
+        author_email=author_email,
+    )
+
+
+def unassign(
+    repo: Union[str, Repo],
+    name: str,
+    stage: str,
+    version: str = None,
+    ref: str = None,
+    message: str = None,
+    simple: bool = False,
+    force: bool = False,
+    delete: bool = False,
+    stdout: bool = False,
+    author: Optional[str] = None,
+    author_email: Optional[str] = None,
+):
+    """Assign stage to specific artifact version"""
+    return GitRegistry.from_repo(repo).unassign(
+        name,
+        stage,
+        version,
+        ref,
+        message=message,
+        simple=simple,
+        force=force,
+        delete=delete,
         stdout=stdout,
         author=author,
         author_email=author_email,

--- a/gto/api.py
+++ b/gto/api.py
@@ -110,6 +110,28 @@ def register(
     )
 
 
+def deregister(
+    repo: Union[str, Repo],
+    name: str,
+    ref: str = None,
+    version: str = None,
+    message: str = None,
+    stdout: bool = False,
+    author: Optional[str] = None,
+    author_email: Optional[str] = None,
+):
+    """Register new artifact version"""
+    return GitRegistry.from_repo(repo).deregister(
+        name=name,
+        ref=ref,
+        version=version,
+        message=message,
+        stdout=stdout,
+        author=author,
+        author_email=author_email,
+    )
+
+
 def promote(
     repo: Union[str, Repo],
     name: str,

--- a/gto/api.py
+++ b/gto/api.py
@@ -352,26 +352,28 @@ def _show_versions(  # pylint: disable=too-many-locals
     first_keys = ["artifact", "version", "stage"]
     versions_ = []
     for v in versions:
-        v["version"] = format_hexsha(v["name"])
+        v["version"] = format_hexsha(v["version"])
         v["stage"] = ", ".join(
             distinct(
                 s["stage"]
-                for s in (
-                    v["assignments"][::-1][:1] if last_stage else v["assignments"][::-1]
-                )
+                for s in (v["stages"][::-1][:1] if last_stage else v["stages"][::-1])
             )
         )
         v["commit_hexsha"] = format_hexsha(v["commit_hexsha"])
-        v["ref"] = v["tag"] or v["commit_hexsha"]
+        # TODO: won't work if len(registrations) > 1
+        v["ref"] = v["registrations"][0]["tag"] or v["commit_hexsha"]
+        v["message"] = v["registrations"][0]["message"]
+        v["author"] = v["registrations"][0]["author"]
         for key in (
             "enrichments",
             "discovered",
-            "tag",
             "commit_hexsha",
-            "name",
-            "message",
-            "author_email",
-            "assignments",
+            # "message",
+            # "author",
+            # "author_email",
+            "stages",
+            "registrations",
+            "deregistrations",
         ):
             v.pop(key)
         # v["enrichments"] = [e["source"] for e in v["enrichments"]]
@@ -435,7 +437,7 @@ def history(  # pylint: disable=too-many-locals
 
     registration = [
         OrderedDict(
-            timestamp=v.created_at,
+            timestamp=v.activated_at,
             artifact=o.artifact,
             event=Event.REGISTRATION,
             version=format_hexsha(v.version),

--- a/gto/api.py
+++ b/gto/api.py
@@ -81,47 +81,29 @@ def remove(repo: Union[str, Repo], name: str):
     return init_index_manager(path=repo).remove(name)
 
 
-def tag(  # pylint: disable=too-many-locals
+def register(
     repo: Union[str, Repo],
     name: str,
-    ref: str = None,
+    ref: str,
     version: str = None,
-    stage: str = None,
-    to_version: str = None,
     message: str = None,
+    simple: bool = None,
+    force: bool = False,
     bump_major: bool = False,
     bump_minor: bool = False,
     bump_patch: bool = False,
     stdout: bool = False,
     author: Optional[str] = None,
     author_email: Optional[str] = None,
-    simple: Optional[bool] = None,
-    force: bool = False,
-    skip_registration: bool = False,
 ):
-    """Register new artifact version or assign stage to specific artifact version"""
-    if stage and version:
-        raise WrongArgs("Can't register both version and assign a stage")
-    if stage:
-        return GitRegistry.from_repo(repo).assign(
-            name,
-            stage,
-            version=to_version,
-            ref=ref,
-            message=message,
-            simple=simple if simple is not None else False,
-            force=force,
-            skip_registration=skip_registration,
-            stdout=stdout,
-            author=author,
-            author_email=author_email,
-        )
+    """Register new artifact version"""
     return GitRegistry.from_repo(repo).register(
         name=name,
         ref=ref,
         version=version,
         message=message,
         simple=simple if simple is not None else True,
+        force=force,
         bump_major=bump_major,
         bump_minor=bump_minor,
         bump_patch=bump_patch,
@@ -131,10 +113,41 @@ def tag(  # pylint: disable=too-many-locals
     )
 
 
-def untag(
+def assign(
     repo: Union[str, Repo],
     name: str,
+    stage: str,
+    version: str = None,
     ref: str = None,
+    name_version: str = None,
+    message: str = None,
+    simple: bool = False,
+    force: bool = False,
+    skip_registration: bool = False,
+    stdout: bool = False,
+    author: Optional[str] = None,
+    author_email: Optional[str] = None,
+):
+    """Assign stage to specific artifact version"""
+    return GitRegistry.from_repo(repo).assign(
+        name=name,
+        stage=stage,
+        version=version,
+        ref=ref,
+        name_version=name_version,
+        message=message,
+        simple=simple,
+        force=force,
+        skip_registration=skip_registration,
+        stdout=stdout,
+        author=author,
+        author_email=author_email,
+    )
+
+
+def deprecate(
+    repo: Union[str, Repo],
+    name: str,
     version: str = None,
     stage: str = None,
     message: str = None,
@@ -145,50 +158,33 @@ def untag(
     author: Optional[str] = None,
     author_email: Optional[str] = None,
 ):
-    "Deregister version or unassign stage"
-    if stage is not None:
+    if stage:
         return GitRegistry.from_repo(repo).unassign(
-            name,
-            stage,
-            version,
-            ref,
+            name=name,
+            stage=stage,
+            version=version,
             message=message,
+            stdout=stdout,
             simple=simple if simple is not None else False,
             force=force,
             delete=delete,
-            stdout=stdout,
             author=author,
             author_email=author_email,
         )
-    return GitRegistry.from_repo(repo).deregister(
-        name=name,
-        ref=ref,
-        version=version,
-        message=message,
-        simple=simple if simple is not None else True,
-        force=force,
-        delete=delete,
-        stdout=stdout,
-        author=author,
-        author_email=author_email,
-    )
-
-
-def deprecate(
-    repo: Union[str, Repo],
-    name: str,
-    ref: str = None,
-    message: str = None,
-    stdout: bool = False,
-    simple: Optional[bool] = None,
-    force: bool = False,
-    delete: bool = False,
-    author: Optional[str] = None,
-    author_email: Optional[str] = None,
-):
+    if version:
+        return GitRegistry.from_repo(repo).deregister(
+            name=name,
+            version=version,
+            message=message,
+            stdout=stdout,
+            simple=simple if simple is not None else True,
+            force=force,
+            delete=delete,
+            author=author,
+            author_email=author_email,
+        )
     return GitRegistry.from_repo(repo).deprecate(
         name=name,
-        ref=ref,
         message=message,
         stdout=stdout,
         simple=simple if simple is not None else True,

--- a/gto/api.py
+++ b/gto/api.py
@@ -5,7 +5,15 @@ from typing import List, Optional, Union
 from funcy import distinct
 from git import Repo
 
-from gto.constants import ARTIFACT, COMMIT, NAME, STAGE, VERSION
+from gto.constants import (
+    ARTIFACT,
+    ASSIGNMENTS_PER_VERSION,
+    COMMIT,
+    NAME,
+    STAGE,
+    VERSION,
+    VERSIONS_PER_STAGE,
+)
 from gto.exceptions import NoRepo, NotImplementedInGTO, WrongArgs
 from gto.ext import EnrichmentInfo
 from gto.index import (
@@ -218,12 +226,18 @@ def find_versions_in_stage(
     repo: Union[str, Repo],
     name: str,
     stage: str,
-    all: bool = False,
+    assignments_per_version=ASSIGNMENTS_PER_VERSION,
+    versions_per_stage=VERSIONS_PER_STAGE,
     registered_only: bool = False,
 ):
     """Return version of artifact with specific stage active"""
     return GitRegistry.from_repo(repo).which(
-        name, stage, raise_if_not_found=False, all=all, registered_only=registered_only
+        name,
+        stage,
+        raise_if_not_found=False,
+        assignments_per_version=assignments_per_version,
+        versions_per_stage=versions_per_stage,
+        registered_only=registered_only,
     )
 
 
@@ -240,8 +254,8 @@ def show(
     all_commits=False,
     truncate_hexsha=False,
     registered_only=False,
-    last_assignments_per_version=-1,
-    last_versions_per_stage=1,
+    assignments_per_version=ASSIGNMENTS_PER_VERSION,
+    versions_per_stage=1,
     table: bool = False,
 ):
     return (
@@ -251,8 +265,8 @@ def show(
             all_branches=all_branches,
             all_commits=all_commits,
             registered_only=registered_only,
-            last_assignments_per_version=last_assignments_per_version,
-            last_versions_per_stage=last_versions_per_stage,
+            assignments_per_version=assignments_per_version,
+            versions_per_stage=versions_per_stage,
             table=table,
             truncate_hexsha=truncate_hexsha,
         )
@@ -262,8 +276,8 @@ def show(
             all_branches=all_branches,
             all_commits=all_commits,
             registered_only=registered_only,
-            last_assignments_per_version=last_assignments_per_version,
-            last_versions_per_stage=last_versions_per_stage,
+            assignments_per_version=assignments_per_version,
+            versions_per_stage=versions_per_stage,
             table=table,
             truncate_hexsha=truncate_hexsha,
         )
@@ -275,8 +289,8 @@ def _show_registry(
     all_branches=False,
     all_commits=False,
     registered_only=False,
-    last_assignments_per_version: int = -1,
-    last_versions_per_stage: int = 1,
+    assignments_per_version: int = ASSIGNMENTS_PER_VERSION,
+    versions_per_stage: int = VERSIONS_PER_STAGE,
     table: bool = False,
     truncate_hexsha: bool = False,
 ):
@@ -298,15 +312,15 @@ def _show_registry(
                         format_hexsha(s.version)
                         for s in o.get_vstages(
                             registered_only=registered_only,
-                            last_assignments_per_version=last_assignments_per_version,
-                            last_versions_per_stage=last_versions_per_stage,
+                            assignments_per_version=assignments_per_version,
+                            versions_per_stage=versions_per_stage,
                         )[name]
                     ]
                 )
                 if name
                 in o.get_vstages(
                     registered_only=registered_only,
-                    last_assignments_per_version=last_assignments_per_version,
+                    assignments_per_version=assignments_per_version,
                 )
                 else None
                 for name in stages
@@ -335,8 +349,8 @@ def _show_versions(  # pylint: disable=too-many-locals
     all_branches=False,
     all_commits=False,
     registered_only=False,
-    last_assignments_per_version: int = -1,
-    last_versions_per_stage: int = 1,
+    assignments_per_version: int = None,
+    versions_per_stage: int = None,
     table: bool = False,
     truncate_hexsha: bool = False,
 ):
@@ -356,8 +370,8 @@ def _show_versions(  # pylint: disable=too-many-locals
     )
     stages = artifact.get_vstages(
         registered_only=registered_only,
-        last_assignments_per_version=last_assignments_per_version,
-        last_versions_per_stage=last_versions_per_stage,
+        assignments_per_version=assignments_per_version,
+        versions_per_stage=versions_per_stage,
     )
     versions = []
     for v in artifact.get_versions(

--- a/gto/api.py
+++ b/gto/api.py
@@ -81,12 +81,13 @@ def remove(repo: Union[str, Repo], name: str):
     return init_index_manager(path=repo).remove(name)
 
 
-def tag(
+def tag(  # pylint: disable=too-many-locals
     repo: Union[str, Repo],
     name: str,
     ref: str = None,
     version: str = None,
     stage: str = None,
+    to_version: str = None,
     message: str = None,
     bump_major: bool = False,
     bump_minor: bool = False,
@@ -98,36 +99,36 @@ def tag(
     force: bool = False,
     skip_registration: bool = False,
 ):
+    """Register new artifact version or assign stage to specific artifact version"""
+    if stage and version:
+        raise WrongArgs("Can't register both version and assign a stage")
     if stage:
-        """Assign stage to specific artifact version"""
         return GitRegistry.from_repo(repo).assign(
             name,
             stage,
-            version,
-            ref,
+            version=to_version,
+            ref=ref,
             message=message,
-            simple=simple if simple is not None else True,
+            simple=simple if simple is not None else False,
             force=force,
             skip_registration=skip_registration,
             stdout=stdout,
             author=author,
             author_email=author_email,
         )
-    else:
-        """Register new artifact version"""
-        return GitRegistry.from_repo(repo).register(
-            name=name,
-            ref=ref,
-            version=version,
-            message=message,
-            simple=simple if simple is not None else False,
-            bump_major=bump_major,
-            bump_minor=bump_minor,
-            bump_patch=bump_patch,
-            stdout=stdout,
-            author=author,
-            author_email=author_email,
-        )
+    return GitRegistry.from_repo(repo).register(
+        name=name,
+        ref=ref,
+        version=version,
+        message=message,
+        simple=simple if simple is not None else True,
+        bump_major=bump_major,
+        bump_minor=bump_minor,
+        bump_patch=bump_patch,
+        stdout=stdout,
+        author=author,
+        author_email=author_email,
+    )
 
 
 def untag(
@@ -144,31 +145,33 @@ def untag(
     author: Optional[str] = None,
     author_email: Optional[str] = None,
 ):
+    "Deregister version or unassign stage"
     if stage is not None:
-        """Assign stage to specific artifact version"""
         return GitRegistry.from_repo(repo).unassign(
             name,
             stage,
             version,
             ref,
             message=message,
-            simple=simple,
+            simple=simple if simple is not None else False,
             force=force,
             delete=delete,
             stdout=stdout,
             author=author,
             author_email=author_email,
         )
-    else:
-        return GitRegistry.from_repo(repo).deregister(
-            name=name,
-            ref=ref,
-            version=version,
-            message=message,
-            stdout=stdout,
-            author=author,
-            author_email=author_email,
-        )
+    return GitRegistry.from_repo(repo).deregister(
+        name=name,
+        ref=ref,
+        version=version,
+        message=message,
+        simple=simple if simple is not None else True,
+        force=force,
+        delete=delete,
+        stdout=stdout,
+        author=author,
+        author_email=author_email,
+    )
 
 
 def deprecate(

--- a/gto/api.py
+++ b/gto/api.py
@@ -285,20 +285,18 @@ def _show_registry(
     reg = GitRegistry.from_repo(repo)
     stages = list(reg.get_stages())
     models_state = {
-        o.name: {
-            "version": format_hexsha(o.get_latest_version(registered_only=True).name)
+        o.artifact: {
+            "version": format_hexsha(o.get_latest_version(registered_only=True).version)
             if o.get_latest_version(registered_only=True)
             else None,
             "stage": {
                 name: format_hexsha(
-                    o.get_assignments(
+                    o.get_stages(
                         registered_only=registered_only, last_stage=last_stage
                     )[name][0].version
                 )
                 if name
-                in o.get_assignments(
-                    registered_only=registered_only, last_stage=last_stage
-                )
+                in o.get_stages(registered_only=registered_only, last_stage=last_stage)
                 else None
                 for name in stages
             },
@@ -424,7 +422,7 @@ def history(  # pylint: disable=too-many-locals
             timestamp=datetime.fromtimestamp(
                 reg.repo.commit(v.commit_hexsha).committed_date
             ),
-            artifact=o.name,
+            artifact=o.artifact,
             event=Event.COMMIT,
             commit=format_hexsha(v.commit_hexsha),
             author=reg.repo.commit(v.commit_hexsha).author.name,
@@ -438,9 +436,9 @@ def history(  # pylint: disable=too-many-locals
     registration = [
         OrderedDict(
             timestamp=v.created_at,
-            artifact=o.name,
+            artifact=o.artifact,
             event=Event.REGISTRATION,
-            version=format_hexsha(v.name),
+            version=format_hexsha(v.version),
             commit=format_hexsha(v.commit_hexsha),
             author=v.author,
             author_email=v.author_email,
@@ -454,7 +452,7 @@ def history(  # pylint: disable=too-many-locals
     assignment = [
         OrderedDict(
             timestamp=p.created_at,
-            artifact=o.name,
+            artifact=o.artifact,
             event=Event.ASSIGNMENT,
             version=format_hexsha(p.version),
             stage=p.stage,
@@ -464,7 +462,7 @@ def history(  # pylint: disable=too-many-locals
             message=p.message,
         )
         for o in artifacts.values()
-        for p in o.stages
+        for p in o.assignments
     ]
 
     events_order = {

--- a/gto/base.py
+++ b/gto/base.py
@@ -12,7 +12,7 @@ from gto.versions import SemVer
 from .exceptions import ArtifactNotFound, ManyVersions, VersionRequired
 
 
-class BasePromotion(BaseModel):
+class BaseAssignment(BaseModel):
     artifact: str
     version: str
     stage: str
@@ -34,7 +34,7 @@ class BaseVersion(BaseModel):
     commit_hexsha: str
     discovered: bool = False
     tag: Optional[str] = None
-    promotions: List[BasePromotion] = []
+    assignments: List[BaseAssignment] = []
     enrichments: List[Enrichment] = []
 
     @property
@@ -47,14 +47,15 @@ class BaseVersion(BaseModel):
         # TODO: this should be read from config, how to pass it down here?
         return SemVer(self.name)
 
-    @property
-    def stage(self):
-        promotions = sorted(self.promotions, key=lambda p: p.created_at)
-        return promotions[-1] if promotions else None
+    def add_assignment(self, assignment: BaseAssignment):
+        self.assignments.append(assignment)
+        self.assignments.sort(key=lambda p: p.created_at)
 
     def dict_status(self):
-        version = self.dict(exclude={"promotions"})
-        version["stage"] = self.stage.dict() if self.stage else None
+        version = self.dict(exclude={"assignments"})
+        version["assignments"] = (
+            [a.dict() for a in self.assignments] if self.assignments else None
+        )
         return version
 
 
@@ -103,12 +104,14 @@ class BaseArtifact(BaseModel):
     @property
     def stages(self):
         return [
-            promotion for version in self.versions for promotion in version.promotions
+            assignment
+            for version in self.versions
+            for assignment in version.assignments
         ]
 
     @property
     def unique_stages(self):
-        return {promotion.stage for promotion in self.stages}
+        return {assignment.stage for assignment in self.stages}
 
     def __repr__(self) -> str:
         versions = ", ".join(f"'{v.name}'" for v in self.versions)
@@ -141,32 +144,35 @@ class BaseArtifact(BaseModel):
             return versions[0]
         return None
 
-    def get_promotions(
-        self, all=False, registered_only=False, sort=VersionSort.SemVer
-    ) -> Dict[str, Union[BasePromotion, List[BasePromotion]]]:
+    def get_assignments(
+        self,
+        registered_only=False,
+        last_stage=False,
+        sort=VersionSort.SemVer,
+    ) -> Dict[str, Union[BaseAssignment, List[BaseAssignment]]]:
         versions = self.get_versions(
             include_non_explicit=not registered_only, sort=sort
         )
         if sort == VersionSort.Timestamp:
             # for this sort we need to sort not versions, as above ^
-            # but promotions themselves
+            # but assignments themselves
             raise NotImplementedError("Sorting by timestamp is not implemented yet")
-        stages = {}  # type: ignore
+        stages: Dict[str, List[BaseAssignment]] = {}
         for version in versions:
-            promotion = version.stage
-            if promotion:
-                stages[promotion.stage] = stages.get(promotion.stage, []) + [promotion]
-        if all:
-            return stages
-        return {stage: promotions[0] for stage, promotions in stages.items()}
+            for a in (
+                version.assignments[::-1][:1] if last_stage else version.assignments
+            ):
+                if a.stage not in stages:
+                    stages[a.stage] = []
+                if a.version not in [i.version for i in stages[a.stage]]:
+                    stages[a.stage].append(a)
+        return stages  # type: ignore
 
     def add_version(self, version: BaseVersion):
         self.versions.append(version)
 
-    def add_promotion(self, promotion: BasePromotion):
-        self.find_version(name=promotion.version).promotions.append(  # type: ignore
-            promotion
-        )
+    def add_assignment(self, assignment: BaseAssignment):
+        self.find_version(name=assignment.version).add_assignment(assignment)  # type: ignore
 
     def update_enrichments(self, version, enrichments):
         self.find_version(
@@ -288,11 +294,11 @@ class BaseRegistryState(BaseModel):
         self, name, stage, raise_if_not_found=True, all=False, registered_only=False
     ):
         """Return stage active in specific stage"""
-        promoted = self.find_artifact(name).get_promotions(
-            all=all, registered_only=registered_only
+        assigned = self.find_artifact(name).get_assignments(
+            registered_only=registered_only
         )
-        if stage in promoted:
-            return promoted[stage]
+        if stage in assigned:
+            return assigned[stage] if all else assigned[stage][0]
         if raise_if_not_found:
             raise ValueError(f"Stage {stage} not found for {name}")
         return None
@@ -323,7 +329,7 @@ class BaseManager(BaseModel):
     # def register(self, name, version, ref, message):
     #     raise NotImplementedError
 
-    # def promote(self, name, stage, ref, message):
+    # def assign(self, name, stage, ref, message):
     #     raise NotImplementedError
 
     def check_ref(self, ref: str, state: BaseRegistryState):

--- a/gto/base.py
+++ b/gto/base.py
@@ -443,9 +443,12 @@ class Artifact(BaseObject):
         versions = [
             v
             for v in self.versions
-            if (v.is_registered and not v.discovered)
-            or (include_discovered and v.discovered)
-            or (include_non_explicit and not v.is_registered)
+            if v.is_active
+            and (
+                (v.is_registered and not v.discovered)
+                or (include_discovered and v.discovered)
+                or (include_non_explicit and not v.is_registered)
+            )
         ]
         return sort_versions(versions, sort=sort, ascending=ascending)
 

--- a/gto/base.py
+++ b/gto/base.py
@@ -18,6 +18,18 @@ class BaseAssignment(BaseModel):
     stage: str
     created_at: datetime
     author: str
+    author_email: Optional[str]  # TODO: remove as optional later
+    message: Optional[str]  # remove as optional later
+    commit_hexsha: str
+    tag: str
+
+
+class BaseUnassignment(BaseModel):
+    artifact: str
+    version: str
+    stage: str
+    created_at: datetime
+    author: str
     author_email: Optional[str]  # remove as optional later
     message: Optional[str]  # remove as optional later
     commit_hexsha: str
@@ -35,6 +47,7 @@ class BaseVersion(BaseModel):
     discovered: bool = False
     tag: Optional[str] = None
     assignments: List[BaseAssignment] = []
+    unassignments: List[BaseUnassignment] = []
     enrichments: List[Enrichment] = []
 
     @property
@@ -50,6 +63,10 @@ class BaseVersion(BaseModel):
     def add_assignment(self, assignment: BaseAssignment):
         self.assignments.append(assignment)
         self.assignments.sort(key=lambda p: p.created_at)
+
+    def add_unassignment(self, unassignment: BaseUnassignment):
+        self.unassignments.append(unassignment)
+        self.unassignments.sort(key=lambda p: p.created_at)
 
     def dict_status(self):
         version = self.dict(exclude={"assignments"})

--- a/gto/base.py
+++ b/gto/base.py
@@ -414,8 +414,8 @@ class Artifact(BaseObject):
     @property
     def is_active(self):
         if len(self.get_events()) == 0:
-            return True
-        return isinstance(self.get_events(direct=True, indirect=False)[0], Creation)
+            return False
+        return not isinstance(self.get_events()[0], Deprecation)
 
     @property
     def activated_at(self):

--- a/gto/cli.py
+++ b/gto/cli.py
@@ -588,7 +588,7 @@ def latest(
         if ref:
             echo(latest_version.tag or latest_version.commit_hexsha)
         else:
-            echo(latest_version.name)
+            echo(latest_version.version)
 
 
 @gto_command(section=CommandGroups.querying)

--- a/gto/cli.py
+++ b/gto/cli.py
@@ -183,7 +183,7 @@ app = Typer(
 
 arg_name = Argument(..., help="Artifact name")
 arg_version = Argument(..., help="Artifact version")
-arg_stage = Argument(..., help="Stage to promote to")
+arg_stage = Argument(..., help="Stage to assign")
 
 option_rev = Option(None, "--rev", help="Repo revision to use", show_default=True)
 option_repo = Option(".", "-r", "--repo", help="Repository to use", show_default=True)
@@ -272,10 +272,13 @@ def gto_callback(
 ):
     """\b
     Git Tag Ops. Turn your Git repository into an Artifact Registry:
-    * Register new versions of artifacts marking releases/significant changes
-    * Promote versions to ordered, named stages to track their lifecycles
-    * GitOps: signal CI/CD automation or downstream systems to act upon these actions
-    * Maintain and query artifact metadata / additional info with Enrichments machinery
+    * Registry: Track new artifacts and their versions for releases and significant
+    changes.
+    * Lifecycle Management: Create actionable stages for versions marking status of
+    artifact or it's readiness to be consumed by a specific environment.
+    * GitOps: Signal CI/CD automation or other downstream systems to act upon these
+    new versions and lifecycle updates.
+    * Enrichments: Annotate and query artifact metadata with additional information.
     """
     if ctx.invoked_subcommand is None and show_version:
         with cli_echo():
@@ -445,12 +448,12 @@ def register(
     )
 
 
-@gto_command(section=CommandGroups.modifying)
-def promote(
+@gto_command(section=CommandGroups.modifying, aliases=["promote"])
+def assign(
     repo: str = option_repo,
     name: str = arg_name,
     stage: str = arg_stage,
-    ref: Optional[str] = Argument(None, help="Git reference to promote"),
+    ref: Optional[str] = Argument(None, help="Git reference to use"),
     version: Optional[str] = Option(
         None,
         "--version",
@@ -466,7 +469,7 @@ def promote(
         help="Use simple notation, e.g. rf#prod instead of rf#prod-5",
     ),
     force: bool = Option(
-        False, help="Promote even if version is already in required Stage"
+        False, help="Assign even if version is already in required Stage"
     ),
     skip_registration: bool = Option(
         False,
@@ -479,33 +482,32 @@ def promote(
     """Move an artifact version to a specific stage
 
     Examples:
-        Promote "nn" to "prod" at specific ref:
-        $ gto promote nn prod abcd123
+        Assign "nn" to "prod" at specific ref:
+        $ gto assign nn prod abcd123
 
-        Promote specific version:
-        $ gto promote nn prod --version v1.0.0
+        Assign specific version:
+        $ gto assign nn prod --version v1.0.0
 
-        Promote at specific ref and name version explicitly:
-        $ gto promote nn prod abcd123 --version v1.0.0
+        Assign at specific ref and name version explicitly:
+        $ gto assign nn prod abcd123 --version v1.0.0
 
-        Promote without increment
-        $ gto promote nn prod HEAD --simple
+        Assign without increment
+        $ gto assign nn prod HEAD --simple
     """
     if ref is not None:
         name_version = version
-        promote_version = None
+        version = None
     elif version is not None:
         name_version = None
-        promote_version = version
     else:
         ref = "HEAD"
         name_version = None
-        promote_version = None
-    gto.api.promote(
+        version = None
+    gto.api.assign(
         repo,
         name,
         stage,
-        promote_version,
+        version,
         ref,
         name_version,
         message=message,
@@ -550,7 +552,7 @@ def which(
     Examples:
         $ gto which nn prod
 
-        Print git tag that did the promotion:
+        Print git tag that did the assignment:
         $ gto which nn prod --ref
     """
     version = gto.api.find_versions_in_stage(
@@ -592,8 +594,8 @@ def check_ref(
     registration: bool = Option(
         False, "--registration", is_flag=True, help="Check if ref registers a version"
     ),
-    promotion: bool = Option(
-        False, "--promotion", is_flag=True, help="Check if ref promotes a version"
+    assignment: bool = Option(
+        False, "--assignment", is_flag=True, help="Check if ref assigns a stage"
     ),
     name: bool = Option(False, "--name", is_flag=True, help="Output artifact name"),
     version: bool = Option(
@@ -601,7 +603,7 @@ def check_ref(
     ),
     stage: bool = Option(False, "--stage", is_flag=True, help="Output artifact stage"),
 ):
-    """Find out the artifact version registered/promoted with ref
+    """Find out the artifact version registered/assigned with ref
 
     Examples:
         $ gto check-ref rf@v1.0.0
@@ -609,7 +611,8 @@ def check_ref(
         $ gto check-ref rf#prod --version
     """
     assert (
-        sum(bool(i) for i in (json, registration, promotion, name, version, stage)) <= 1
+        sum(bool(i) for i in (json, registration, assignment, name, version, stage))
+        <= 1
     ), "Only one output formatting flags is allowed"
     result = {
         action: {name: version.dict() for name, version in found.items()}
@@ -632,19 +635,19 @@ def check_ref(
     elif stage:
         if version_dict:
             raise NotImplementedInGTO(
-                "--stage is not implemented for version promotion git tag"
+                "--stage is not implemented for version assignment git tag"
             )
         if stage_dict:
             echo(stage_dict["stage"])
-    elif (registration or not promotion) and version_dict:
+    elif (registration or not assignment) and version_dict:
         echo(
             f"""{EMOJI_OK} Version "{version_dict["name"]}" of artifact """
             f""""{version_dict["artifact"]}" was registered"""
         )
-    elif (promotion or not registration) and stage_dict:
+    elif (assignment or not registration) and stage_dict:
         echo(
-            f"""{EMOJI_OK} Version "{stage_dict["version"]}" of artifact """
-            f""""{stage_dict["artifact"]}" was promoted to "{stage_dict["stage"]}" stage"""
+            f"""{EMOJI_OK} Stage "{stage_dict["stage"]}" was assigned to version"""
+            f'''"{stage_dict["version"]}" of artifact "{stage_dict["artifact"]}"'''
         )
 
 
@@ -658,6 +661,9 @@ def show(
     plain: bool = option_plain,
     name_only: bool = option_name_only,
     registered_only: bool = option_registered_only,
+    last_stage: bool = Option(
+        False, "--ls", "--last-stage", help="Show only the last stage for each version"
+    ),
 ):
     """Show the registry state
 
@@ -682,6 +688,7 @@ def show(
             all_branches=all_branches,
             all_commits=all_commits,
             registered_only=registered_only,
+            last_stage=last_stage,
             table=False,
         )
         if name_only:
@@ -696,6 +703,7 @@ def show(
                 all_branches=all_branches,
                 all_commits=all_commits,
                 registered_only=registered_only,
+                last_stage=last_stage,
                 table=True,
                 truncate_hexsha=True,
             ),

--- a/gto/cli.py
+++ b/gto/cli.py
@@ -376,7 +376,7 @@ def gto_command(*args, section="other", aliases=None, parent=app, **kwargs):
                         )
                     )
                     echo(
-                        "Please report it here: <https://github.com/iterative/gto/issues>"
+                        "Please report it here running with '--traceback' flag: <https://github.com/iterative/gto/issues>"
                     )
                 raise typer.Exit(1) from e
             finally:

--- a/gto/cli.py
+++ b/gto/cli.py
@@ -683,6 +683,8 @@ def check_ref(
     result = gto.api.check_ref(repo, ref)
     if len(result) > 1:
         NotImplementedInGTO("Checking refs that created 1+ events is not supported")
+    if len(result) == 0:
+        return
     found_event = result[0]
     if json:
         format_echo(found_event.dict_state(exclude={"priority", "addition"}), "json")

--- a/gto/cli.py
+++ b/gto/cli.py
@@ -591,7 +591,7 @@ def latest(
     latest_version = gto.api.find_latest_version(repo, name)
     if latest_version:
         if ref:
-            echo(latest_version.tag or latest_version.commit_hexsha)
+            echo(latest_version.ref or latest_version.commit_hexsha)
         else:
             echo(latest_version.version)
 
@@ -623,7 +623,7 @@ def which(
             #     version.reverse()
             format_echo([v.version for v in version], "lines")
         elif ref:
-            echo(version.tag or version.commit_hexsha)
+            echo(version.ref or version.commit_hexsha)
         else:
             echo(version.version)
 

--- a/gto/cli.py
+++ b/gto/cli.py
@@ -13,9 +13,14 @@ from typer.core import TyperCommand, TyperGroup
 
 import gto
 from gto.constants import ASSIGNMENTS_PER_VERSION, VERSIONS_PER_STAGE
-from gto.exceptions import GTOException, NotImplementedInGTO, WrongArgs
+from gto.exceptions import (
+    AmbiguousArg,
+    GTOException,
+    NotImplementedInGTO,
+    WrongArgs,
+)
 from gto.ui import EMOJI_FAIL, EMOJI_GTO, EMOJI_OK, bold, cli_echo, color, echo
-from gto.utils import format_echo, make_ready_to_serialize
+from gto.utils import format_echo, make_ready_to_serialize, resolve_ref
 
 
 class CommandGroups:
@@ -186,6 +191,15 @@ app = Typer(
 arg_name = Argument(..., help="Artifact name")
 arg_version = Argument(..., help="Artifact version")
 arg_stage = Argument(..., help="Stage to assign")
+option_version = Option(None, "--version", help="Version name in SemVer format")
+option_stage = Option(None, "--stage", help="Stage to assign")
+option_delete = Option(
+    False,
+    "-d",
+    "--delete",
+    is_flag=True,
+    help="Delete the git tag(s) instead of creating the new one",
+)
 
 # Typer options to control git-related operations
 option_rev = Option(None, "--rev", help="Repo revision to use", show_default=True)
@@ -204,13 +218,27 @@ option_message = Option(
     None, "--message", "-m", help="Message to annotate git tag with"
 )
 option_force = Option(
-    False, help="Create a git tag even if it already exists and is in effect"
-)
-option_simple = Option(
     False,
-    "--simple",
+    "--force",
     is_flag=True,
-    help="Use simple notation, e.g. rf#prod instead of rf#prod-5",
+    help="Create a git tag even if it already exists and is in effect",
+)
+
+
+def name_callback(ctx: typer.Context, param: typer.CallbackParam, value: str):
+    if ctx.resilient_parsing:
+        return
+    allowed_values = ["auto", "true", "false"]
+    if value not in allowed_values:
+        raise typer.BadParameter(f"Only one of {allowed_values} is allowed")
+    return {"auto": None, "true": True, "false": False}[value]
+
+
+option_simple = Option(
+    "auto",
+    "--simple",
+    help="[auto, true, false] Use simple notation, e.g. rf#prod instead of rf#prod-5",
+    callback=name_callback,
 )
 
 # Typer options to control and filter the output
@@ -436,13 +464,12 @@ def remove(repo: str = option_repo, name: str = arg_name):
 
 
 @gto_command(section=CommandGroups.modifying)
-def register(
+def tag(
     repo: str = option_repo,
     name: str = arg_name,
-    ref: str = Argument("HEAD", help="Git reference to use for registration"),
-    version: Optional[str] = Option(
-        None, "--version", "--ver", help="Version name in SemVer format"
-    ),
+    ref: str = Argument(None, help="Git reference to use for registration"),
+    version: Optional[str] = option_version,
+    stage: str = option_stage,
     message: Optional[str] = option_message,
     bump_major: bool = Option(
         False, "--bump-major", is_flag=True, help="Bump major version"
@@ -453,48 +480,7 @@ def register(
     bump_patch: bool = Option(
         False, "--bump-patch", is_flag=True, help="Bump patch version"
     ),
-):
-    """Create an artifact version to signify an important, published or released iteration
-
-    Examples:
-        Register new version at HEAD:
-        $ gto register nn
-
-        Register new version at a specific ref:
-        $ gto register nn abc1234
-
-        Assign version name explicitly:
-        $ gto register nn --version v1.0.0
-
-        Choose a part to bump version by:
-        $ gto register nn --bump-minor
-    """
-    gto.api.register(
-        repo=repo,
-        name=name,
-        ref=ref or "HEAD",
-        version=version,
-        message=message,
-        bump_major=bump_major,
-        bump_minor=bump_minor,
-        bump_patch=bump_patch,
-        stdout=True,
-    )
-
-
-@gto_command(section=CommandGroups.modifying, aliases=["promote"])
-def assign(
-    repo: str = option_repo,
-    name: str = arg_name,
-    stage: str = arg_stage,
-    ref: Optional[str] = Argument(None, help="Git reference to use"),
-    version: Optional[str] = Option(
-        None,
-        "--version",
-        help="If you provide REF, this will be used to name new version",
-    ),
-    message: Optional[str] = option_message,
-    simple: bool = option_simple,
+    simple: str = option_simple,
     force: bool = option_force,
     skip_registration: bool = Option(
         False,
@@ -504,39 +490,103 @@ def assign(
         help="Don't register a version at specified commit",
     ),
 ):
-    """Assign stage to specific artifact version
+    """Register a new version or assing a stage
 
     Examples:
-        Assign "nn" to "prod" at specific ref:
-        $ gto assign nn prod abcd123
+        Register a new version:
+        $ gto tag nn --version v1.0.0
 
-        Assign specific version:
-        $ gto assign nn prod --version v1.0.0
-
-        Assign at specific ref and name version explicitly:
-        $ gto assign nn prod abcd123 --version v1.0.0
-
-        Assign without increment
-        $ gto assign nn prod HEAD --simple
+        Assign "prod" to "nn" version "v1.0.0":
+        $ gto tag nn --version v1.0.0 --stage prod
     """
-    if ref is not None:
-        name_version = version
-        version = None
-    elif version is not None:
-        name_version = None
-    else:
-        ref = "HEAD"
-        name_version = None
-        version = None
-    gto.api.assign(
+    gto.api.tag(
         repo,
         name,
-        stage,
-        version,
-        ref,
-        name_version,
+        ref=ref,
+        version=version,
+        stage=stage,
         message=message,
-        simple=simple,
+        bump_major=bump_major,
+        bump_minor=bump_minor,
+        bump_patch=bump_patch,
+        simple=simple,  # type: ignore
+        force=force,
+        skip_registration=skip_registration,
+        stdout=True,
+    )
+
+
+@gto_command(section=CommandGroups.modifying, hidden=True)
+def tag2(
+    repo: str = option_repo,
+    name: str = arg_name,
+    ref: str = Argument(None, help="Git reference to use for registration"),
+    version: str = Argument(None, help="Version name in SemVer format"),
+    stage: str = Argument(None, help="Stage to assign"),
+    message: Optional[str] = option_message,
+    bump_major: bool = Option(
+        False, "--bump-major", is_flag=True, help="Bump major version"
+    ),
+    bump_minor: bool = Option(
+        False, "--bump-minor", is_flag=True, help="Bump minor version"
+    ),
+    bump_patch: bool = Option(
+        False, "--bump-patch", is_flag=True, help="Bump patch version"
+    ),
+    simple: str = option_simple,
+    force: bool = option_force,
+    skip_registration: bool = Option(
+        False,
+        "--sr",
+        "--skip-registration",
+        is_flag=True,
+        help="Don't register a version at specified commit",
+    ),
+):
+    if stage is not None:
+        # gto tag x3 HEAD v0.0.1 prod
+        raise GTOException("ref, version and stage can't be specified simultaneously")
+    elif version is not None:
+        from gto.versions import SemVer
+
+        if SemVer.is_valid(ref) and SemVer.is_valid(version):
+            # gto tag x3 v0.0.1 v0.0.1
+            ref, version, stage = ref, version, None
+        elif SemVer.is_valid(version):
+            # gto tag x3 HEAD v0.0.1
+            ref, version, stage = ref, version, None
+        elif SemVer.is_valid(ref):
+            # gto tag x3 v0.0.1 prod
+            # 'ref' is a git ref or a model version?
+            if resolve_ref(repo, ref, raise_if_not_found=False) is None:
+                ref, version, stage = None, ref, version
+            else:
+                raise AmbiguousArg(
+                    f"Argument value '{ref}' is ambiguous. If it's a Git ref, use "
+                    "'refs/tags/{ref}' or 'refs/heads/{ref}'. If it's an artifact version, "
+                    "use Git ref instead, like '{name}@{ref}'"
+                )
+        else:
+            # gto tag x3 HEAD prod
+            ref, version, stage = ref, None, version
+    elif ref is not None:
+        # gto tag x2 HEAD
+        ref, version, stage = ref, None, None
+    else:
+        # gto tag x3
+        ref, version, stage = "HEAD", None, None
+
+    gto.api.tag(
+        repo,
+        name,
+        ref=ref,
+        version=version,
+        stage=stage,
+        message=message,
+        bump_major=bump_major,
+        bump_minor=bump_minor,
+        bump_patch=bump_patch,
+        simple=simple,  # type: ignore
         force=force,
         skip_registration=skip_registration,
         stdout=True,
@@ -544,18 +594,14 @@ def assign(
 
 
 @gto_command(section=CommandGroups.modifying)
-def unassign(
+def untag(
     repo: str = option_repo,
     name: str = arg_name,
-    stage: str = arg_stage,
     ref: Optional[str] = Argument(None, help="Git reference to use"),
-    version: Optional[str] = Option(
-        None,
-        "--version",
-        help="Artifact version to unassign the stage from",
-    ),
+    version: Optional[str] = option_version,
+    stage: Optional[str] = option_stage,
     message: Optional[str] = option_message,
-    simple: bool = option_simple,
+    simple: str = option_simple,
     force: bool = option_force,
     delete: bool = Option(
         False,
@@ -565,25 +611,53 @@ def unassign(
         help="Delete the git tag that did the assignment instead of creating the new one",
     ),
 ):
-    """Unassign stage from specific artifact version
+    """Deregister a version or unassign a stage
 
     Examples:
-        Unassign "prod" from "nn" at specific ref:
-        $ gto unassign nn prod abcd123
+        Deregister a version "v1.0.0" of "nn":
+        $ gto untag nn --version v1.0.0
 
-        Unassign "prod" from "nn" at specific version:
-        $ gto unassign nn prod --version v1.0.0
+        Unassign "prod" from "nn" version "v1.0.0":
+        $ gto untag nn --version v1.0.0 --stage prod
     """
     if ref is None and version is None:
         ref = "HEAD"
-    gto.api.unassign(
-        repo,
-        name,
-        stage,
-        version,
-        ref,
+    gto.api.untag(
+        repo=repo,
+        name=name,
+        ref=ref,
+        version=version,
+        stage=stage,
         message=message,
-        simple=simple,
+        simple=simple,  # type: ignore
+        force=force,
+        delete=delete,
+        stdout=True,
+    )
+
+
+@gto_command(section=CommandGroups.modifying)
+def deprecate(
+    repo: str = option_repo,
+    name: str = arg_name,
+    ref: Optional[str] = Argument(None, help="Git reference to use"),
+    message: Optional[str] = option_message,
+    simple: str = option_simple,
+    force: bool = option_force,
+    delete: bool = option_delete,
+):
+    """Deregister a version or unassign a stage
+
+    Examples:
+        Deprecate an artifact "nn":
+        $ gto deprecate nn
+    """
+    gto.api.deprecate(
+        repo=repo,
+        name=name,
+        ref=ref,
+        message=message,
+        simple=simple,  # type: ignore
         force=force,
         delete=delete,
         stdout=True,

--- a/gto/cli.py
+++ b/gto/cli.py
@@ -695,8 +695,17 @@ def show(
     plain: bool = option_plain,
     name_only: bool = option_name_only,
     registered_only: bool = option_registered_only,
-    last_stage: bool = Option(
-        False, "--ls", "--last-stage", help="Show only the last stage for each version"
+    last_assignments_per_version: int = Option(
+        -1,
+        "--la",
+        "--last-assignments-per-version",
+        help="Show N last stages for each version. -1 for all",
+    ),
+    last_versions_per_stage: int = Option(
+        1,
+        "--lv",
+        "--last-versions-per-stage",
+        help="Show N last versions for each stage. -1 for all. Applied after 'last_assignments_per_versions'",
     ),
 ):
     """Show the registry state
@@ -722,7 +731,8 @@ def show(
             all_branches=all_branches,
             all_commits=all_commits,
             registered_only=registered_only,
-            last_stage=last_stage,
+            last_assignments_per_version=last_assignments_per_version,
+            last_versions_per_stage=last_versions_per_stage,
             table=False,
         )
         if name_only:
@@ -737,7 +747,8 @@ def show(
                 all_branches=all_branches,
                 all_commits=all_commits,
                 registered_only=registered_only,
-                last_stage=last_stage,
+                last_assignments_per_version=last_assignments_per_version,
+                last_versions_per_stage=last_versions_per_stage,
                 table=True,
                 truncate_hexsha=True,
             ),
@@ -745,16 +756,6 @@ def show(
             format_table="plain" if plain else "fancy_outline",
             if_empty="Nothing found in the current workspace",
         )
-
-
-# Actions = StrEnum("Actions", ALIAS.REGISTER + ALIAS.PROMOTE, type=str)  # type: ignore
-# action: List[Actions] = Argument(None),  # type: ignore
-# @click.option(
-#     "--action",
-#     required=False,
-#     type=click.Choice(ALIAS.COMMIT + ALIAS.REGISTER + ALIAS.PROMOTE),
-#     nargs=-1,
-# )
 
 
 @gto_command(section=CommandGroups.querying)

--- a/gto/cli.py
+++ b/gto/cli.py
@@ -596,17 +596,39 @@ def deprecate(
         Unassign a stage:
         $ gto deprecate nn v0.0.1 prod
     """
-    gto.api.deprecate(
-        repo=repo,
-        name=name,
-        version=version,
-        stage=stage,
-        message=message,
-        simple=simple,  # type: ignore
-        force=force,
-        delete=delete,
-        stdout=True,
-    )
+    if stage:
+        gto.api.unassign(
+            repo=repo,
+            name=name,
+            version=version,
+            stage=stage,
+            message=message,
+            simple=simple,  # type: ignore
+            force=force,
+            delete=delete,
+            stdout=True,
+        )
+    elif version:
+        gto.api.unregister(
+            repo=repo,
+            name=name,
+            version=version,
+            message=message,
+            simple=simple,  # type: ignore
+            force=force,
+            delete=delete,
+            stdout=True,
+        )
+    else:
+        gto.api.deprecate(
+            repo=repo,
+            name=name,
+            message=message,
+            simple=simple,  # type: ignore
+            force=force,
+            delete=delete,
+            stdout=True,
+        )
 
 
 @gto_command(section=CommandGroups.querying)

--- a/gto/config.py
+++ b/gto/config.py
@@ -14,7 +14,7 @@ from gto.exceptions import (
     ValidationError,
     WrongConfig,
 )
-from gto.ext import Enrichment, find_enrichment_types, find_enrichments
+from gto.ext import EnrichmentReader, find_enrichment_types, find_enrichments
 
 yaml = YAML(typ="safe", pure=True)
 yaml.default_flow_style = False
@@ -38,7 +38,7 @@ class EnrichmentConfig(BaseModel):
     type: str
     config: Dict = {}
 
-    def load(self) -> Enrichment:
+    def load(self) -> EnrichmentReader:
         return find_enrichment_types()[self.type](**self.config)
 
 
@@ -67,7 +67,7 @@ class NoFileConfig(BaseSettings):
             raise UnknownStage(name, self.STAGES)
 
     @property
-    def enrichments(self) -> Dict[str, Enrichment]:
+    def enrichments(self) -> Dict[str, EnrichmentReader]:
         res = {e.source: e for e in (e.load() for e in self.ENRICHMENTS)}
         if self.AUTOLOAD_ENRICHMENTS:
             return {**find_enrichments(), **res}

--- a/gto/config.py
+++ b/gto/config.py
@@ -8,6 +8,7 @@ from pydantic import BaseModel, BaseSettings, validator
 from pydantic.env_settings import InitSettingsSource
 from ruamel.yaml import YAML
 
+from gto.constants import name_regexp
 from gto.exceptions import (
     UnknownStage,
     UnknownType,
@@ -23,7 +24,7 @@ CONFIG_FILE_NAME = ".gto"
 
 
 def check_name_is_valid(name):
-    return bool(re.match(r"[a-z][a-z0-9-/]*[a-z0-9]$", name))
+    return bool(re.search(name_regexp, name))
 
 
 def assert_name_is_valid(name):

--- a/gto/constants.py
+++ b/gto/constants.py
@@ -18,6 +18,7 @@ NUMBER = "number"
 class Action(Enum):
     REGISTER = "register"
     ASSIGN = "assign"
+    UNASSIGN = "unassign"
 
 
 class Event(Enum):

--- a/gto/constants.py
+++ b/gto/constants.py
@@ -17,7 +17,13 @@ NUMBER = "number"
 
 class Action(Enum):
     REGISTER = "register"
-    PROMOTE = "promote"
+    ASSIGN = "assign"
+
+
+class Event(Enum):
+    COMMIT = "commit"
+    REGISTRATION = "registration"
+    ASSIGNMENT = "assignment"
 
 
 class VersionSort(Enum):

--- a/gto/constants.py
+++ b/gto/constants.py
@@ -1,3 +1,4 @@
+import re
 from enum import Enum
 
 COMMIT = "commit"
@@ -11,13 +12,23 @@ NAME = "name"
 PATH = "path"
 VERSION = "version"
 STAGE = "stage"
-NUMBER = "number"
+COUNTER = "counter"
 
 
 class Action(Enum):
+    DEREGISTER = "deregister"
     REGISTER = "register"
     ASSIGN = "assign"
     UNASSIGN = "unassign"
+
+
+name = "[a-z][a-z0-9-/]*[a-z0-9]"
+semver = r"(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)(?:-(?P<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?"
+counter = "?P<counter>[0-9]+"
+name_regexp = re.compile(f"^{name}$")
+tag_regexp = re.compile(
+    f"^(?P<artifact>{name})(#(?P<stage>{name})|@(?P<version>v{semver}))(?P<cancel>!?)(#({counter}))?$"
+)
 
 
 class VersionSort(Enum):

--- a/gto/constants.py
+++ b/gto/constants.py
@@ -23,3 +23,7 @@ class Action(Enum):
 class VersionSort(Enum):
     SemVer = "semver"
     Timestamp = "timestamp"
+
+
+ASSIGNMENTS_PER_VERSION = -1
+VERSIONS_PER_STAGE = 1

--- a/gto/constants.py
+++ b/gto/constants.py
@@ -4,6 +4,7 @@ COMMIT = "commit"
 REF = "ref"
 TAG = "tag"
 
+ARTIFACT = "artifact"
 ACTION = "action"
 TYPE = "type"
 NAME = "name"

--- a/gto/constants.py
+++ b/gto/constants.py
@@ -1,10 +1,8 @@
 from enum import Enum
 
+COMMIT = "commit"
 REF = "ref"
-# COMMIT = "commit"
 TAG = "tag"
-# BRANCH = "branch"
-# FILE = "file"
 
 ACTION = "action"
 TYPE = "type"
@@ -19,12 +17,6 @@ class Action(Enum):
     REGISTER = "register"
     ASSIGN = "assign"
     UNASSIGN = "unassign"
-
-
-class Event(Enum):
-    COMMIT = "commit"
-    REGISTRATION = "registration"
-    ASSIGNMENT = "assignment"
 
 
 class VersionSort(Enum):

--- a/gto/constants.py
+++ b/gto/constants.py
@@ -16,6 +16,8 @@ COUNTER = "counter"
 
 
 class Action(Enum):
+    CREATE = "create"
+    DEPRECATE = "deprecate"
     DEREGISTER = "deregister"
     REGISTER = "register"
     ASSIGN = "assign"
@@ -27,7 +29,7 @@ semver = r"(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)(?
 counter = "?P<counter>[0-9]+"
 name_regexp = re.compile(f"^{name}$")
 tag_regexp = re.compile(
-    f"^(?P<artifact>{name})(#(?P<stage>{name})|@(?P<version>v{semver}))(?P<cancel>!?)(#({counter}))?$"
+    f"^(?P<artifact>{name})(((#(?P<stage>{name})|@(?P<version>v{semver}))(?P<cancel>!?))|@((?P<deprecated>deprecated)|(?P<created>created)))(#({counter}))?$"
 )
 
 

--- a/gto/exceptions.py
+++ b/gto/exceptions.py
@@ -107,11 +107,21 @@ class UnknownStage(GTOException):
         super().__init__(self.message)
 
 
-class NoActivePromotion(GTOException):
+class NoActiveAssignment(GTOException):
     _message = "No version in stage '{stage}' was found for '{name}'"
 
     def __init__(self, stage, name) -> None:
         self.message = self._message.format(stage=stage, name=name)
+        super().__init__(self.message)
+
+
+class NoStageForVersion(GTOException):
+    _message = "The artifact '{artifact}' version '{version}' is not in stage '{stage}'"
+
+    def __init__(self, artifact, version, stage) -> None:
+        self.message = self._message.format(
+            artifact=artifact, version=version, stage=stage
+        )
         super().__init__(self.message)
 
 

--- a/gto/exceptions.py
+++ b/gto/exceptions.py
@@ -133,6 +133,10 @@ class RefNotFound(GTOException):
         super().__init__(self.message)
 
 
+class AmbiguousArg(GTOException):
+    pass
+
+
 class InvalidVersion(GTOException):
     pass
 

--- a/gto/exceptions.py
+++ b/gto/exceptions.py
@@ -171,6 +171,14 @@ class TagExists(GTOException):
         super().__init__(self.message)
 
 
+class TagNotFound(GTOException):
+    message = "tag '{name}' is not found"
+
+    def __init__(self, name) -> None:
+        self.message = self.message.format(name=name)
+        super().__init__(self.message)
+
+
 class ValidationError(GTOException):
     pass
 

--- a/gto/ext.py
+++ b/gto/ext.py
@@ -6,7 +6,7 @@ from typing import Dict, Optional, Type
 import entrypoints
 from pydantic import BaseModel
 
-ENRICHMENT_ENRTYPOINT = "gto.enrichment"
+ENRICHMENT_ENTRYPOINT = "gto.enrichment"
 
 
 def import_string(path):
@@ -34,7 +34,7 @@ class EnrichmentInfo(BaseModel, ABC):
         raise NotImplementedError
 
 
-class Enrichment(BaseModel, ABC):
+class EnrichmentReader(BaseModel, ABC):
     source: str
 
     @abstractmethod
@@ -55,7 +55,7 @@ class Enrichment(BaseModel, ABC):
 #         return self.repr
 
 
-# class CLIEnrichment(Enrichment):
+# class CLIEnrichment(EnrichmentReader):
 #     cmd: str
 #     info_type: Union[str, Type[EnrichmentInfo]] = CLIEnrichmentInfo
 
@@ -88,28 +88,28 @@ class Enrichment(BaseModel, ABC):
 
 @lru_cache()
 def _find_enrichments():
-    eps = entrypoints.get_group_named(ENRICHMENT_ENRTYPOINT)
+    eps = entrypoints.get_group_named(ENRICHMENT_ENTRYPOINT)
     return {k: ep.load() for k, ep in eps.items()}
 
 
 @lru_cache()
-def find_enrichments() -> Dict[str, Enrichment]:
+def find_enrichments() -> Dict[str, EnrichmentReader]:
     enrichments = _find_enrichments()
     res = {}
     for name, e in enrichments.items():
         # if isinstance(e, type) and issubclass(e, Enrichment) and not e.__fields_set__:
-        if isinstance(e, type) and issubclass(e, Enrichment):
+        if isinstance(e, type) and issubclass(e, EnrichmentReader):
             res[name] = e()
-        if isinstance(e, Enrichment):
+        if isinstance(e, EnrichmentReader):
             res[name] = e
     return res
 
 
 @lru_cache()
-def find_enrichment_types() -> Dict[str, Type[Enrichment]]:
+def find_enrichment_types() -> Dict[str, Type[EnrichmentReader]]:
     enrichments = _find_enrichments()
     return {
         k: e
         for k, e in enrichments.items()
-        if isinstance(e, type) and issubclass(e, Enrichment)
+        if isinstance(e, type) and issubclass(e, EnrichmentReader)
     }

--- a/gto/ext_dvc.py
+++ b/gto/ext_dvc.py
@@ -3,7 +3,7 @@
 # from pydantic import BaseModel
 # from ruamel.yaml import safe_load
 
-# from gto.ext import Enrichment, EnrichmentInfo
+# from gto.ext import EnrichmentReader, EnrichmentInfo
 
 
 # class DVCEnrichmentInfo(EnrichmentInfo):
@@ -18,7 +18,7 @@
 #         return f"""DVC-tracked [{self.size} bytes]"""
 
 
-# class DVCEnrichment(Enrichment):
+# class DVCEnrichment(EnrichmentReader):
 #     def describe(self, obj: str) -> Optional[DVCEnrichmentInfo]:
 #         try:
 #             with open(obj + ".dvc", encoding="utf8") as f:

--- a/gto/ext_mlem.py
+++ b/gto/ext_mlem.py
@@ -7,7 +7,7 @@
 # from mlem.core.objects import DatasetMeta, MlemMeta, ModelMeta
 # from pydantic import BaseModel
 
-# from gto.ext import Enrichment, EnrichmentInfo
+# from gto.ext import EnrichmentReader, EnrichmentInfo
 
 
 # class MlemInfo(EnrichmentInfo):
@@ -27,7 +27,7 @@
 #         return description
 
 
-# class MlemEnrichment(Enrichment):
+# class MlemEnrichment(EnrichmentReader):
 #     source = "mlem"
 
 #     def describe(self, repo, obj: str, rev: Optional[str]) -> Optional[MlemInfo]:

--- a/gto/index.py
+++ b/gto/index.py
@@ -183,7 +183,7 @@ class BaseIndexManager(BaseModel, ABC):
         raise NotImplementedError
 
     def add(self, name, type, path, must_exist, labels, description, update):
-        for arg in [name] + (labels or []):
+        for arg in [name] + (list(labels) or []):
             assert_name_is_valid(arg)
         if type:
             self.config.assert_type(type)

--- a/gto/index.py
+++ b/gto/index.py
@@ -183,7 +183,7 @@ class BaseIndexManager(BaseModel, ABC):
         raise NotImplementedError
 
     def add(self, name, type, path, must_exist, labels, description, update):
-        for arg in [name] + (list(labels) or []):
+        for arg in [name] + list(labels or []):
             assert_name_is_valid(arg)
         if type:
             self.config.assert_type(type)

--- a/gto/registry.py
+++ b/gto/registry.py
@@ -5,7 +5,7 @@ import git
 from git import InvalidGitRepositoryError, NoSuchPathError, Repo
 from pydantic import BaseModel
 
-from gto.base import BaseAssignment, BaseRegistryState
+from gto.base import Assignment, BaseRegistryState
 from gto.config import (
     CONFIG_FILE_NAME,
     RegistryConfig,
@@ -71,12 +71,11 @@ class GitRegistry(BaseModel):
         state = BaseRegistryState()
         state = self.version_manager.update_state(state)
         state = self.stage_manager.update_state(state)
-        state = self.enrichment_manager.update_state(
-            state,
-            all_branches=all_branches,
-            all_commits=all_commits,
-        )
-        state.sort()
+        # state = self.enrichment_manager.update_state(
+        #     state,
+        #     all_branches=all_branches,
+        #     all_commits=all_commits,
+        # )
         return state
 
     def get_artifacts(
@@ -130,7 +129,7 @@ class GitRegistry(BaseModel):
         # check that this commit don't have a version already
         found_version = found_artifact.find_version(commit_hexsha=ref)
         if found_version is not None and found_version.is_registered:
-            raise VersionExistsForCommit(name, found_version.name)
+            raise VersionExistsForCommit(name, found_version.version)
         # if version name is provided, use it
         if version:
             if found_artifact.find_version(name=version) is not None:
@@ -144,7 +143,7 @@ class GitRegistry(BaseModel):
             last_version = found_artifact.get_latest_version(registered_only=True)
             if last_version:
                 version = (
-                    SemVer(last_version.name)
+                    SemVer(last_version.version)
                     .bump(
                         bump_major=bump_major,
                         bump_minor=bump_minor,
@@ -189,7 +188,7 @@ class GitRegistry(BaseModel):
         stdout=False,
         author: Optional[str] = None,
         author_email: Optional[str] = None,
-    ) -> BaseAssignment:
+    ) -> Assignment:
         """Assign stage to specific artifact version"""
         assert_name_is_valid(name)
         self.config.assert_stage(stage)
@@ -214,7 +213,7 @@ class GitRegistry(BaseModel):
             if found_version:
                 if name_version:
                     raise WrongArgs(
-                        f"Can't register '{SemVer(name_version).version}', since '{found_version.name}' is registered already at this ref"
+                        f"Can't register '{SemVer(name_version).version}', since '{found_version.version}' is registered already at this ref"
                     )
             elif not skip_registration:
                 self.register(name, version=name_version, ref=ref, stdout=stdout)
@@ -259,7 +258,7 @@ class GitRegistry(BaseModel):
         stdout=False,
         author: Optional[str] = None,
         author_email: Optional[str] = None,
-    ) -> BaseAssignment:
+    ) -> Assignment:
         """Assign stage to specific artifact version"""
         assert_name_is_valid(name)
         self.config.assert_stage(stage)

--- a/gto/registry.py
+++ b/gto/registry.py
@@ -186,6 +186,7 @@ class GitRegistry(BaseModel):
         )
         if stdout:
             echo(f"Created git tag '{tag}' that registers version")
+            self._echo_git_suggestion(tag)
         return self._return_event(tag)
 
     def deregister(  # pylint: disable=too-many-locals
@@ -242,6 +243,7 @@ class GitRegistry(BaseModel):
         )
         if stdout:
             echo(f"Created git tag '{tag}' that deregisters version")
+            self._echo_git_suggestion(tag)
         return self._return_event(tag)
 
     def assign(  # pylint: disable=too-many-locals
@@ -316,6 +318,7 @@ class GitRegistry(BaseModel):
             echo(
                 f"Created git tag '{tag}' that assigns stage to version '{found_version.version}'"
             )
+            self._echo_git_suggestion(tag)
         return self._return_event(tag)
 
     def unassign(  # pylint: disable=too-many-locals
@@ -372,6 +375,7 @@ class GitRegistry(BaseModel):
             echo(
                 f"Created git tag '{tag}' that unassigns stage from version '{found_version.version}'"
             )
+            self._echo_git_suggestion(tag)
         return self._return_event(tag)
 
     def deprecate(
@@ -414,6 +418,7 @@ class GitRegistry(BaseModel):
         )
         if stdout:
             echo(f"Created git tag '{tag}' that deprecates artifact")
+            self._echo_git_suggestion(tag)
         return self._return_event(tag)
 
     def _check_args(self, name, version, ref, stage=None):
@@ -439,6 +444,11 @@ class GitRegistry(BaseModel):
         event = event[0]
         return event
 
+    @staticmethod
+    def _echo_git_suggestion(tag):
+        echo("To push the changes upstream, run:")
+        echo(f"    git push {tag}")
+
     def _delete_tags(self, tags, stdout):
         tags = list(tags)
         for tag in tags:
@@ -447,7 +457,7 @@ class GitRegistry(BaseModel):
                 echo(f"Deleted git tag '{tag}'")
         if stdout:
             echo("To push the changes upstream, run:")
-            echo(f"git push {' '.join(tags)} --delete")
+            echo(f"    git push {' '.join(tags)} --delete")
 
     def check_ref(self, ref: str):
         "Find out what was registered/assigned in this ref"

--- a/gto/registry.py
+++ b/gto/registry.py
@@ -224,9 +224,11 @@ class GitRegistry(BaseModel):
             not force
             and found_version
             and found_version.stages
-            and any(s == stage for s in found_version.stages)
+            and any(vstage.stage == stage for vstage in found_version.get_vstages())
         ):
-            raise WrongArgs(f"Version is already in stage '{stage}'")
+            raise WrongArgs(
+                f"Version '{found_version.version}' is already in stage '{stage}'"
+            )
         # TODO: getting tag name as a result and using it
         # is leaking implementation details in base module
         # it's roughly ok to have until we add other implementations
@@ -236,7 +238,7 @@ class GitRegistry(BaseModel):
             stage,
             ref=ref,
             message=message
-            or f"Assigning stage {stage} to artifact {name} version {version}",
+            or f"Assigning stage {stage} to artifact {name} version {found_version.version}",
             simple=simple,
             author=author,
             author_email=author_email,
@@ -298,7 +300,7 @@ class GitRegistry(BaseModel):
             stage,
             ref=found_version.commit_hexsha,
             message=message
-            or f"Unassigning stage '{stage}' to artifact '{name}' version '{version}'",
+            or f"Unassigning stage '{stage}' to artifact '{name}' version '{found_version.version}'",
             simple=simple,
             delete=delete,
             author=author,

--- a/gto/registry.py
+++ b/gto/registry.py
@@ -173,7 +173,7 @@ class GitRegistry(BaseModel):
         )
         if stdout:
             echo(
-                f"Created git tag '{registered_version.tag}' that registers a new version"
+                f"Created git tag '{registered_version.ref}' that registers a new version"
             )
         return registered_version
 
@@ -238,7 +238,10 @@ class GitRegistry(BaseModel):
             stage,
             ref=ref,
             message=message
-            or f"Assigning stage {stage} to artifact {name} version {found_version.version}",
+            or f"Assigning stage {stage} to artifact {name} "
+            + (
+                f"version {found_version.version}" if found_version else f"commit {ref}"
+            ),
             simple=simple,
             author=author,
             author_email=author_email,

--- a/gto/registry.py
+++ b/gto/registry.py
@@ -457,7 +457,7 @@ class GitRegistry(BaseModel):
                 echo(f"Deleted git tag '{tag}'")
         if stdout:
             echo("To push the changes upstream, run:")
-            echo(f"    git push {' '.join(tags)} --delete")
+            echo(f"    git push {' '.join(tags)} --delete".replace("!", "/!"))
 
     def check_ref(self, ref: str):
         "Find out what was registered/assigned in this ref"

--- a/gto/registry.py
+++ b/gto/registry.py
@@ -71,11 +71,11 @@ class GitRegistry(BaseModel):
         state = BaseRegistryState()
         state = self.version_manager.update_state(state)
         state = self.stage_manager.update_state(state)
-        # state = self.enrichment_manager.update_state(
-        #     state,
-        #     all_branches=all_branches,
-        #     all_commits=all_commits,
-        # )
+        state = self.enrichment_manager.update_state(
+            state,
+            all_branches=all_branches,
+            all_commits=all_commits,
+        )
         return state
 
     def get_artifacts(
@@ -245,7 +245,7 @@ class GitRegistry(BaseModel):
             )
         return assignment
 
-    def unassign(
+    def unassign(  # pylint: disable=too-many-locals
         self,
         name,
         stage,
@@ -279,7 +279,7 @@ class GitRegistry(BaseModel):
             raise WrongArgs(
                 f"Stage '{stage}' is not assigned to a version '{found_version.version}'"
             )
-        if delete and (message or author or author_email or simple or force):
+        if delete and any([message, author, author_email, simple, force]):
             raise WrongArgs(
                 "Deleting a git tag doesn't require any of 'message', 'force', 'simple', 'author' or 'author_email'"
             )

--- a/gto/registry.py
+++ b/gto/registry.py
@@ -342,11 +342,22 @@ class GitRegistry(BaseModel):
         return self.get_state().find_commit(name, version)
 
     def which(
-        self, name, stage, raise_if_not_found=True, all=False, registered_only=False
+        self,
+        name,
+        stage,
+        raise_if_not_found=True,
+        assignments_per_version=None,
+        versions_per_stage=None,
+        registered_only=False,
     ):
         """Return stage active in specific stage"""
         return self.get_state().which(
-            name, stage, raise_if_not_found, all=all, registered_only=registered_only
+            name,
+            stage,
+            raise_if_not_found,
+            assignments_per_version=assignments_per_version,
+            versions_per_stage=versions_per_stage,
+            registered_only=registered_only,
         )
 
     def latest(self, name: str, all: bool = False, registered: bool = True):

--- a/gto/registry.py
+++ b/gto/registry.py
@@ -296,7 +296,7 @@ class GitRegistry(BaseModel):
         tag = self.stage_manager.unassign(  # type: ignore
             name,
             stage,
-            ref=ref,
+            ref=found_version.commit_hexsha,
             message=message
             or f"Unassigning stage '{stage}' to artifact '{name}' version '{version}'",
             simple=simple,
@@ -332,7 +332,8 @@ class GitRegistry(BaseModel):
             for aname, artifact in state.get_artifacts().items()
             if aname == name
             for event in artifact.get_events()
-            if event.tag == ref
+            # TODO: support matching the shortened commit hashes
+            if event.ref == ref
         ]
 
     def find_commit(self, name, version):

--- a/gto/registry.py
+++ b/gto/registry.py
@@ -196,7 +196,7 @@ class GitRegistry(BaseModel):
             self._echo_git_suggestion(tag)
         return self._return_event(tag)
 
-    def deregister(  # pylint: disable=too-many-locals
+    def unregister(  # pylint: disable=too-many-locals
         self,
         name,
         ref=None,

--- a/gto/tag.py
+++ b/gto/tag.py
@@ -14,7 +14,6 @@ from .base import (
     BaseManager,
     BaseRegistryState,
     Registration,
-    Version,
 )
 from .constants import ACTION, NAME, NUMBER, STAGE, TAG, VERSION, Action
 from .exceptions import (
@@ -47,7 +46,7 @@ def name_tag(
 
     if action in (Action.ASSIGN, Action.UNASSIGN):
         if simple:
-            tag = f"{name}{ActionSign[action.ASSIGN]}{stage}"
+            tag = f"{name}{ActionSign[Action.ASSIGN]}{stage}"
             if action == Action.UNASSIGN:
                 tag += ActionSign[Action.UNASSIGN]
             return tag
@@ -55,7 +54,7 @@ def name_tag(
             raise MissingArg(arg="repo")
         numbers = []
         for tag in repo.tags:
-            parsed = parse_name(tag.name, raise_on_fail=False)
+            parsed = parse_name(tag.name, raise_on_fail=False)  # type: ignore
             if (
                 parsed
                 and (parsed[NAME] == name)
@@ -231,7 +230,7 @@ def delete_tag(repo: git.Repo, name: str):
         raise TagNotFound(name=name) from e
 
 
-def registration_from_tag(tag: git.Tag) -> Version:
+def registration_from_tag(tag: git.Tag) -> Registration:
     mtag = parse_tag(tag)
     return Registration(
         artifact=mtag.name,

--- a/gto/tag.py
+++ b/gto/tag.py
@@ -189,11 +189,7 @@ def find(
     if tags is None:
         if repo is None:
             raise MissingArg(arg="repo")
-        tags = [
-            t
-            for t in repo.tags
-            if parse_name(t.name, raise_on_fail=False) and t.tag is not None
-        ]
+        tags = [t for t in repo.tags if parse_name(t.name, raise_on_fail=False)]
     if action:
         tags = [t for t in tags if parse_name(t.name)[ACTION] in action]
     if name:
@@ -202,6 +198,8 @@ def find(
         tags = [t for t in tags if parse_name(t.name).get(VERSION) == version]
     if stage:
         tags = [t for t in tags if parse_name(t.name).get(STAGE) == stage]
+    # remove lightweight tags - better to do later so the function is faster
+    tags = [t for t in tags if t.tag is not None]
     if sort == "by_time":
         tags = sorted(tags, key=lambda t: t.tag.tagged_date)
     else:

--- a/gto/tag.py
+++ b/gto/tag.py
@@ -308,23 +308,6 @@ class TagVersionManager(TagManager):
             tagger_email=author_email,
         )
 
-    def check_ref(self, ref: str, state: BaseRegistryState):
-        try:
-            _ = self.repo.tags[ref]
-            art_name = parse_name(ref)[NAME]
-            version_name = parse_name(ref)[VERSION]
-        except (KeyError, ValueError, IndexError):
-            # logging.warning(
-            #     "Provided ref doesn't exist or it is not a tag that registers a version"
-            # )
-            return {}
-        return {
-            name: version
-            for name, artifact in state.get_artifacts().items()
-            for version in artifact.versions
-            if name == art_name and version.version == version_name
-        }
-
 
 class TagStageManager(TagManager):
     actions: FrozenSet[Action] = frozenset((Action.ASSIGN,))
@@ -377,17 +360,3 @@ class TagStageManager(TagManager):
             tagger_email=author_email,
         )
         return tag
-
-    def check_ref(self, ref: str, state: BaseRegistryState):
-        try:
-            tag = self.repo.tags[ref]
-            _ = parse_name(ref)[STAGE]
-            art_name = parse_name(ref)[NAME]
-        except (KeyError, ValueError, IndexError):
-            return {}
-        return {
-            name: assignment
-            for name, artifact in state.get_artifacts().items()
-            for assignment in artifact.assignments + artifact.unassignments
-            if name == art_name and assignment.tag == tag.name
-        }

--- a/gto/tag.py
+++ b/gto/tag.py
@@ -283,7 +283,7 @@ class TagManager(BaseManager):  # pylint: disable=abstract-method
 class TagArtifactManager(TagManager):
     actions: FrozenSet[Action] = frozenset((Action.CREATE, Action.DEPRECATE))
 
-    def create(self):
+    def create(self):  # pylint: disable=no-self-use
         raise NotImplementedInGTO(
             "If you want to create artifact, register a version or assign a stage for it"
         )
@@ -294,20 +294,9 @@ class TagArtifactManager(TagManager):
         ref,
         message,
         simple,
-        delete,
         author: Optional[str] = None,
         author_email: Optional[str] = None,
     ):
-        if delete:
-            raise NotImplementedInGTO(
-                "`delete=True` is not implemented for deprecation"
-            )
-            # TODO: find all the tags somehow
-            # tags = []
-            # for tag in tags:
-            #     delete_tag(tag)
-            # return tags
-
         tag = name_tag(
             Action.DEPRECATE,
             name,
@@ -357,11 +346,12 @@ class TagVersionManager(TagManager):
         version,
         ref,
         message,
+        simple,
         author: Optional[str] = None,
         author_email: Optional[str] = None,
     ):
         tag = name_tag(
-            Action.DEREGISTER, name, version=version, repo=self.repo, simple=True
+            Action.DEREGISTER, name, version=version, repo=self.repo, simple=simple
         )
         create_tag(
             self.repo,
@@ -405,15 +395,9 @@ class TagStageManager(TagManager):
         ref,
         message,
         simple,
-        delete,
         author: Optional[str] = None,
         author_email: Optional[str] = None,
     ) -> str:
-        if delete:
-            # TODO: should be Action.ASSIGN?
-            return delete_tag(
-                self.repo, name_tag(Action.UNASSIGN, name, stage=stage, repo=self.repo)
-            )
         tag = name_tag(
             Action.UNASSIGN, name, stage=stage, repo=self.repo, simple=simple
         )

--- a/gto/utils.py
+++ b/gto/utils.py
@@ -73,6 +73,9 @@ def format_echo(result, format, format_table=None, if_empty="", missing_value="-
         if result:
             for line in result:
                 click.echo(line)
+    elif format == "line":
+        if result:
+            click.echo(result)
     else:
         raise NotImplementedError(f"Format {format} is not implemented")
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -85,13 +85,13 @@ def showcase(
     # bump version automatically
     gto.api.register(path, "rf", "HEAD")
 
-    gto.api.promote(path, "nn", "staging", promote_version=nn_vname)
-    gto.api.promote(path, "rf", "production", promote_version=rf_vname)
-    sleep(1)  # this is needed to ensure right order of promotions in later checks
+    gto.api.assign(path, "nn", "staging", version=nn_vname)
+    gto.api.assign(path, "rf", "production", version=rf_vname)
+    sleep(1)  # this is needed to ensure right order of assignments in later checks
     # the problem is git tags doesn't have miliseconds precision, so we need to wait a bit
-    gto.api.promote(path, "rf", "staging", promote_ref="HEAD")
+    gto.api.assign(path, "rf", "staging", ref="HEAD")
     sleep(1)
-    gto.api.promote(path, "rf", "production", promote_ref=repo.head.ref.commit.hexsha)
+    gto.api.assign(path, "rf", "production", ref=repo.head.ref.commit.hexsha)
     sleep(1)
-    gto.api.promote(path, "rf", "production", promote_version=rf_vname, force=True)
+    gto.api.assign(path, "rf", "production", version=rf_vname, force=True)
     return path, repo, write_file, first_commit, second_commit

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -118,7 +118,7 @@ def test_register_deregister(repo_with_artifact):
     assert latest.author == author
     assert latest.author_email == author_email
 
-    gto.api.deprecate(repo=repo.working_dir, name=name, version=vname2)
+    gto.api.deregister(repo=repo.working_dir, name=name, version=vname2)
     latest = gto.api.find_latest_version(repo.working_dir, name)
     assert latest.version == vname1
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -118,7 +118,7 @@ def test_register_deregister(repo_with_artifact):
     assert latest.author == author
     assert latest.author_email == author_email
 
-    gto.api.deregister(repo.working_dir, name, version=vname2)
+    gto.api.deprecate(repo=repo.working_dir, name=name, version=vname2)
     latest = gto.api.find_latest_version(repo.working_dir, name)
     assert latest.version == vname1
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -85,7 +85,7 @@ def test_api_info_commands_repo_with_artifact(
     gto.api.history(repo.working_dir)
 
 
-def test_register(repo_with_artifact):
+def test_register_deregister(repo_with_artifact):
     repo, name = repo_with_artifact
     vname1, vname2 = "v1.0.0", "v1.0.1"
     gto.api.register(repo.working_dir, name, "HEAD", vname1)
@@ -98,7 +98,9 @@ def test_register(repo_with_artifact):
         "anything",
         must_exist=False,
     )
-    repo.index.commit("Irrelevant action to create a git commit")
+    repo.index.commit(
+        "Irrelevant action to create a git commit to register another version"
+    )
     message = "Some message"
     author = "GTO"
     author_email = "gto@iterative.ai"
@@ -115,6 +117,10 @@ def test_register(repo_with_artifact):
     assert latest.message == message
     assert latest.author == author
     assert latest.author_email == author_email
+
+    gto.api.deregister(repo.working_dir, name, version=vname2)
+    latest = gto.api.find_latest_version(repo.working_dir, name)
+    assert latest.version == vname1
 
 
 def test_assign(repo_with_artifact: Tuple[git.Repo, str]):
@@ -259,7 +265,7 @@ def test_check_ref_catch_the_bug(repo_with_artifact: Tuple[git.Repo, Callable]):
         [f"{NAME}#staging#1", f"{NAME}#prod#2", f"{NAME}#dev#3"],
     ):
         events = gto.api.check_ref(repo, tag)
-        assert len(events) == 1, "Should return one event"
+        assert len(events) == 1, events
         assert events[0].ref == assignment.tag == tag
 
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -91,7 +91,7 @@ def test_register(repo_with_artifact):
     vname1, vname2 = "v1.0.0", "v1.0.1"
     gto.api.register(repo.working_dir, name, "HEAD", vname1)
     latest = gto.api.find_latest_version(repo.working_dir, name)
-    assert latest.name == vname1
+    assert latest.version == vname1
     gto.api.annotate(
         repo.working_dir,
         "something-irrelevant",
@@ -112,7 +112,7 @@ def test_register(repo_with_artifact):
         author_email=author_email,
     )
     latest = gto.api.find_latest_version(repo.working_dir, name)
-    assert latest.name == vname2
+    assert latest.version == vname2
     assert latest.message == message
     assert latest.author == author
     assert latest.author_email == author_email

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -118,7 +118,7 @@ def test_register_deregister(repo_with_artifact):
     assert latest.author == author
     assert latest.author_email == author_email
 
-    gto.api.deregister(repo=repo.working_dir, name=name, version=vname2)
+    gto.api.unregister(repo=repo.working_dir, name=name, version=vname2)
     latest = gto.api.find_latest_version(repo.working_dir, name)
     assert latest.version == vname1
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -135,9 +135,10 @@ def test_assign(repo_with_artifact: Tuple[git.Repo, str]):
         author=author,
         author_email=author_email,
     )
-    assignment = gto.api.find_versions_in_stage(repo.working_dir, name, stage)
+    assignments = gto.api.find_versions_in_stage(repo.working_dir, name, stage)
+    assert len(assignments) == 1
     check_obj(
-        assignment.dict_state(),
+        assignments[0].dict_state(),
         dict(
             artifact=name,
             version="v0.0.1",
@@ -166,8 +167,9 @@ def test_assign_skip_registration(repo_with_artifact: Tuple[git.Repo, str]):
             skip_registration=True,
         )
     gto.api.assign(repo.working_dir, name, stage, ref="HEAD", skip_registration=True)
-    assignment = gto.api.find_versions_in_stage(repo.working_dir, name, stage)
-    assert not SemVer.is_valid(assignment.version)
+    assignments = gto.api.find_versions_in_stage(repo.working_dir, name, stage)
+    assert len(assignments) == 1
+    assert not SemVer.is_valid(assignments[0].version)
 
 
 def test_assign_force_is_needed(repo_with_artifact: Tuple[git.Repo, str]):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -198,88 +198,6 @@ def test_commands(showcase):
     )
 
 
-def test_tag_untag(repo_with_commit: Tuple[git.Repo, Callable]):
-    repo, write_file = repo_with_commit
-    _check_successful_cmd(
-        "tag",
-        ["-r", repo.working_dir, "x1"],
-        "Created git tag 'x1@v0.0.1'\n",
-    )
-    _check_successful_cmd(
-        "untag",
-        ["-r", repo.working_dir, "x1"],
-        "Created git tag 'x1@v0.0.1!'\n",
-    )
-
-    _check_successful_cmd(
-        "tag",
-        ["-r", repo.working_dir, "x2", "HEAD"],
-        "Created git tag 'x2@v0.0.1'\n",
-    )
-    _check_successful_cmd(
-        "untag",
-        ["-r", repo.working_dir, "x2", "HEAD"],
-        "Created git tag 'x2@v0.0.1!'\n",
-    )
-
-    _check_successful_cmd(
-        "tag",
-        ["-r", repo.working_dir, "x3", repo.commit().hexsha],
-        "Created git tag 'x3@v0.0.1'\n",
-    )
-    _check_successful_cmd(
-        "tag",
-        ["-r", repo.working_dir, "x3", repo.commit().hexsha, "--stage", "prod"],
-        "Created git tag 'x3#prod#1'\n",
-    )
-    _check_successful_cmd(
-        "tag",
-        ["-r", repo.working_dir, "x3", "--version", "v0.0.1", "--stage", "dev"],
-        "Created git tag 'x3#dev#2'\n",
-    )
-    _check_successful_cmd(
-        "untag",
-        ["-r", repo.working_dir, "x3", repo.commit().hexsha, "--stage", "prod"],
-        "Created git tag 'x3#prod!#3'\n",
-    )
-    _check_successful_cmd(
-        "untag",
-        ["-r", repo.working_dir, "x3", "--version", "v0.0.1", "--stage", "dev"],
-        "Created git tag 'x3#dev!#4'\n",
-    )
-    _check_successful_cmd(
-        "untag",
-        ["-r", repo.working_dir, "x3", repo.commit().hexsha],
-        "Created git tag 'x3@v0.0.1!'\n",
-    )
-
-    _check_successful_cmd(
-        "tag",
-        ["-r", repo.working_dir, "x4", repo.commit().hexsha, "--version", "v1.0.0"],
-        "Created git tag 'x4@v1.0.0'\n",
-    )
-    _check_successful_cmd(
-        "untag",
-        ["-r", repo.working_dir, "x4", "--version", "v1.0.0"],
-        "Created git tag 'x4@v1.0.0!'\n",
-    )
-
-    _check_failing_cmd(
-        "tag",
-        [
-            "-r",
-            repo.working_dir,
-            "x4",
-            repo.commit().hexsha,
-            "--version",
-            "v1.0.0",
-            "--stage",
-            "prod",
-        ],
-        "❌ One and only one of (version, ref) must be specified.\n",
-    )
-
-
 EXPECTED_DESCRIBE_OUTPUT_2 = """{
     "type": "new-type",
     "path": "new/path",
@@ -362,19 +280,23 @@ def test_register(repo_with_commit: Tuple[git.Repo, Callable]):
     _check_successful_cmd(
         "register",
         ["-r", repo.working_dir, "a1"],
-        "Created git tag 'a1@v0.0.1'\n",
+        "Created git tag 'a1@v0.0.1' that registers version\n"
+        "To push the changes upstream, run:\n"
+        "    git push a1@v0.0.1\n",
     )
 
     _check_successful_cmd(
         "register",
         ["-r", repo.working_dir, "a2", "--version", "v1.2.3"],
-        "Created git tag 'a2@v1.2.3'\n",
+        "Created git tag 'a2@v1.2.3' that registers version\n"
+        "To push the changes upstream, run:\n"
+        "    git push a2@v1.2.3\n",
     )
 
     _check_failing_cmd(
         "register",
         ["-r", repo.working_dir, "a3", "--version", "1.2.3"],
-        "❌ Cannot parse tag name 'a3@1.2.3'\n",
+        "❌ Supplied version '1.2.3' cannot be parsed\n",
     )
 
 
@@ -382,11 +304,20 @@ def test_assign(repo_with_commit: Tuple[git.Repo, Callable]):
     repo, write_file = repo_with_commit
 
     _check_successful_cmd(
+        "register",
+        ["-r", repo.working_dir, "nn1"],
+        "Created git tag 'nn1@v0.0.1' that registers version\n"
+        "To push the changes upstream, run:\n"
+        "    git push nn1@v0.0.1\n",
+    )
+    # this check depends on the previous one
+    _check_successful_cmd(
         "assign",
         ["-r", repo.working_dir, "nn1", "prod", "HEAD"],
-        "Created git tag 'nn1@v0.0.1'\n" "Created git tag 'nn1#prod#1'\n",
+        "Created git tag 'nn1#prod#1' that assigns stage to version 'v0.0.1'\n"
+        "To push the changes upstream, run:\n"
+        "    git push nn1#prod#1\n",
     )
-
     # this check depends on the previous assignment
     _check_failing_cmd(
         "assign",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -123,6 +123,11 @@ def test_commands(showcase):
     )
     _check_successful_cmd(
         "which",
+        ["-r", path, "rf", "staging", "--all"],
+        "v1.2.4\n",
+    )
+    _check_successful_cmd(
+        "which",
         ["-r", path, "rf", "production", "--ref"],
         "rf#production#3\n",
     )
@@ -158,7 +163,7 @@ def test_commands(showcase):
     _check_successful_cmd(
         "check-ref",
         ["-r", path, "rf#production#3", "--version"],
-        "v1.2.4\n",  # since this version was promoted
+        "v1.2.4\n",
     )
     _check_successful_cmd(
         "check-ref",
@@ -167,8 +172,8 @@ def test_commands(showcase):
     )
     _check_successful_cmd(
         "check-ref",
-        ["-r", path, "rf@v1.2.4", "--promotion"],
-        "",  # since this tag doesn't promote to any stage
+        ["-r", path, "rf@v1.2.4", "--assignment"],
+        "",  # since this tag doesn't assign any stage
     )
     _check_successful_cmd(
         "check-ref",
@@ -182,8 +187,8 @@ def test_commands(showcase):
     )
     _check_successful_cmd(
         "check-ref",
-        ["-r", path, "rf#production#3", "--promotion"],
-        '✅  Version "v1.2.4" of artifact "rf" was promoted to "production" stage\n',
+        ["-r", path, "rf#production#3", "--assignment"],
+        '✅  Stage "production" was assigned to version"v1.2.4" of artifact "rf"\n',
     )
 
 
@@ -285,25 +290,25 @@ def test_register(repo_with_commit: Tuple[git.Repo, Callable]):
     )
 
 
-def test_promote(repo_with_commit: Tuple[git.Repo, Callable]):
+def test_assign(repo_with_commit: Tuple[git.Repo, Callable]):
     repo, write_file = repo_with_commit
 
     _check_successful_cmd(
-        "promote",
+        "assign",
         ["-r", repo.working_dir, "nn1", "prod", "HEAD"],
         "Created git tag 'nn1@v0.0.1' that registers a new version\n"
-        "Created git tag 'nn1#prod#1' that promotes 'v0.0.1'\n",
+        "Created git tag 'nn1#prod#1' that assigns 'prod' to 'v0.0.1'\n",
     )
 
-    # this check depends on the previous promotion
+    # this check depends on the previous assignment
     _check_failing_cmd(
-        "promote",
+        "assign",
         ["-r", repo.working_dir, "nn1", "stage", "HEAD", "--version", "v1.0.0"],
         "❌ Can't register 'v1.0.0', since 'v0.0.1' is registered already at this ref\n",
     )
 
     _check_failing_cmd(
-        "promote",
+        "assign",
         ["-r", repo.working_dir, "nn2", "prod", "HEAD", "--version", "1.0.0"],
         "❌ Version '1.0.0' is not valid. Example of valid version: 'v1.0.0'\n",
     )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -190,6 +190,12 @@ def test_commands(showcase):
         ["-r", path, "rf#production#3"],
         '✅  Stage "production" was assigned to version "v1.2.4" of artifact "rf"\n',
     )
+    # TODO: make unsuccessful
+    _check_successful_cmd(
+        "check-ref",
+        ["-r", path, "this-tag-does-not-exist"],
+        "",
+    )
 
 
 EXPECTED_DESCRIBE_OUTPUT_2 = """{
@@ -274,19 +280,19 @@ def test_register(repo_with_commit: Tuple[git.Repo, Callable]):
     _check_successful_cmd(
         "register",
         ["-r", repo.working_dir, "a1"],
-        "Created git tag 'a1@v0.0.1' that registers a new version\n",
+        "Created git tag 'a1@v0.0.1'\n",
     )
 
     _check_successful_cmd(
         "register",
         ["-r", repo.working_dir, "a2", "--version", "v1.2.3"],
-        "Created git tag 'a2@v1.2.3' that registers a new version\n",
+        "Created git tag 'a2@v1.2.3'\n",
     )
 
     _check_failing_cmd(
         "register",
         ["-r", repo.working_dir, "a3", "--version", "1.2.3"],
-        "❌ Version '1.2.3' is not valid. Example of valid version: 'v1.0.0'\n",
+        "❌ Cannot parse tag name 'a3@1.2.3'\n",
     )
 
 
@@ -296,8 +302,7 @@ def test_assign(repo_with_commit: Tuple[git.Repo, Callable]):
     _check_successful_cmd(
         "assign",
         ["-r", repo.working_dir, "nn1", "prod", "HEAD"],
-        "Created git tag 'nn1@v0.0.1' that registers a new version\n"
-        "Created git tag 'nn1#prod#1' that assigns 'prod' to 'v0.0.1'\n",
+        "Created git tag 'nn1@v0.0.1'\n" "Created git tag 'nn1#prod#1'\n",
     )
 
     # this check depends on the previous assignment

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -198,6 +198,88 @@ def test_commands(showcase):
     )
 
 
+def test_tag(repo_with_commit: Tuple[git.Repo, callable]):
+    repo, write_file = repo_with_commit
+    _check_successful_cmd(
+        "tag",
+        ["-r", repo.working_dir, "x1"],
+        "Created git tag 'x1@v0.0.1'\n",
+    )
+    _check_successful_cmd(
+        "tag",
+        ["-r", repo.working_dir, "x2", "HEAD"],
+        "Created git tag 'x2@v0.0.1'\n",
+    )
+    _check_successful_cmd(
+        "tag",
+        ["-r", repo.working_dir, "x3", repo.commit().hexsha],
+        "Created git tag 'x3@v0.0.1'\n",
+    )
+    _check_successful_cmd(
+        "tag",
+        ["-r", repo.working_dir, "x3", repo.commit().hexsha, "--stage", "prod"],
+        "Created git tag 'x3#prod#1'\n",
+    )
+    _check_successful_cmd(
+        "tag",
+        ["-r", repo.working_dir, "x3", "--version", "v0.0.1", "--stage", "dev"],
+        "Created git tag 'x3#dev#2'\n",
+    )
+    _check_successful_cmd(
+        "tag",
+        ["-r", repo.working_dir, "x4", repo.commit().hexsha, "--version", "v1.0.0"],
+        "Created git tag 'x4@v1.0.0'\n",
+    )
+    _check_failing_cmd(
+        "tag",
+        [
+            "-r",
+            repo.working_dir,
+            "x4",
+            repo.commit().hexsha,
+            "--version",
+            "v1.0.0",
+            "--stage",
+            "prod",
+        ],
+        "❌ One and only one of (version, ref) must be specified.\n",
+    )
+
+
+def test_tag2(repo_with_commit: Tuple[git.Repo, callable]):
+    repo, write_file = repo_with_commit
+    _check_successful_cmd(
+        "tag2",
+        ["-r", repo.working_dir, "x1"],
+        "Created git tag 'x1@v0.0.1'\n",
+    )
+    _check_successful_cmd(
+        "tag2",
+        ["-r", repo.working_dir, "x2", "HEAD"],
+        "Created git tag 'x2@v0.0.1'\n",
+    )
+    _check_successful_cmd(
+        "tag2",
+        ["-r", repo.working_dir, "x3", repo.commit().hexsha],
+        "Created git tag 'x3@v0.0.1'\n",
+    )
+    _check_successful_cmd(
+        "tag2",
+        ["-r", repo.working_dir, "x3", repo.commit().hexsha, "prod"],
+        "Created git tag 'x3#prod#1'\n",
+    )
+    _check_successful_cmd(
+        "tag2",
+        ["-r", repo.working_dir, "x3", "v0.0.1", "dev"],
+        "Created git tag 'x3#dev#2'\n",
+    )
+    _check_successful_cmd(
+        "tag2",
+        ["-r", repo.working_dir, "x4", repo.commit().hexsha, "v1.0.0"],
+        "Created git tag 'x4@v1.0.0'\n",
+    )
+
+
 EXPECTED_DESCRIBE_OUTPUT_2 = """{
     "type": "new-type",
     "path": "new/path",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -198,7 +198,7 @@ def test_commands(showcase):
     )
 
 
-def test_tag(repo_with_commit: Tuple[git.Repo, callable]):
+def test_tag_untag(repo_with_commit: Tuple[git.Repo, Callable]):
     repo, write_file = repo_with_commit
     _check_successful_cmd(
         "tag",
@@ -206,10 +206,22 @@ def test_tag(repo_with_commit: Tuple[git.Repo, callable]):
         "Created git tag 'x1@v0.0.1'\n",
     )
     _check_successful_cmd(
+        "untag",
+        ["-r", repo.working_dir, "x1"],
+        "Created git tag 'x1@v0.0.1!'\n",
+    )
+
+    _check_successful_cmd(
         "tag",
         ["-r", repo.working_dir, "x2", "HEAD"],
         "Created git tag 'x2@v0.0.1'\n",
     )
+    _check_successful_cmd(
+        "untag",
+        ["-r", repo.working_dir, "x2", "HEAD"],
+        "Created git tag 'x2@v0.0.1!'\n",
+    )
+
     _check_successful_cmd(
         "tag",
         ["-r", repo.working_dir, "x3", repo.commit().hexsha],
@@ -226,10 +238,32 @@ def test_tag(repo_with_commit: Tuple[git.Repo, callable]):
         "Created git tag 'x3#dev#2'\n",
     )
     _check_successful_cmd(
+        "untag",
+        ["-r", repo.working_dir, "x3", repo.commit().hexsha, "--stage", "prod"],
+        "Created git tag 'x3#prod!#3'\n",
+    )
+    _check_successful_cmd(
+        "untag",
+        ["-r", repo.working_dir, "x3", "--version", "v0.0.1", "--stage", "dev"],
+        "Created git tag 'x3#dev!#4'\n",
+    )
+    _check_successful_cmd(
+        "untag",
+        ["-r", repo.working_dir, "x3", repo.commit().hexsha],
+        "Created git tag 'x3@v0.0.1!'\n",
+    )
+
+    _check_successful_cmd(
         "tag",
         ["-r", repo.working_dir, "x4", repo.commit().hexsha, "--version", "v1.0.0"],
         "Created git tag 'x4@v1.0.0'\n",
     )
+    _check_successful_cmd(
+        "untag",
+        ["-r", repo.working_dir, "x4", "--version", "v1.0.0"],
+        "Created git tag 'x4@v1.0.0!'\n",
+    )
+
     _check_failing_cmd(
         "tag",
         [
@@ -246,7 +280,7 @@ def test_tag(repo_with_commit: Tuple[git.Repo, callable]):
     )
 
 
-def test_tag2(repo_with_commit: Tuple[git.Repo, callable]):
+def test_tag2(repo_with_commit: Tuple[git.Repo, Callable]):
     repo, write_file = repo_with_commit
     _check_successful_cmd(
         "tag2",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -11,7 +11,7 @@ from typer.testing import CliRunner
 from gto.api import _get_index
 from gto.cli import app
 
-from .utils import _check_obj
+from .utils import check_obj
 
 
 def _check_successful_cmd(cmd: str, args: list, expected_stdout: Optional[str]):
@@ -172,23 +172,23 @@ def test_commands(showcase):
     )
     _check_successful_cmd(
         "check-ref",
-        ["-r", path, "rf@v1.2.4", "--assignment"],
-        "",  # since this tag doesn't assign any stage
+        ["-r", path, "rf@v1.2.4", "--event"],
+        "registration\n",
     )
     _check_successful_cmd(
         "check-ref",
-        ["-r", path, "rf@v1.2.4", "--registration"],
+        ["-r", path, "rf@v1.2.4"],
         '✅  Version "v1.2.4" of artifact "rf" was registered\n',
     )
     _check_successful_cmd(
         "check-ref",
-        ["-r", path, "rf#production#3", "--registration"],
-        "",
+        ["-r", path, "rf#production#3", "--event"],
+        "assignment\n",
     )
     _check_successful_cmd(
         "check-ref",
-        ["-r", path, "rf#production#3", "--assignment"],
-        '✅  Stage "production" was assigned to version"v1.2.4" of artifact "rf"\n',
+        ["-r", path, "rf#production#3"],
+        '✅  Stage "production" was assigned to version "v1.2.4" of artifact "rf"\n',
     )
 
 
@@ -243,7 +243,7 @@ def test_annotate(empty_git_repo: Tuple[git.Repo, Callable]):
     artifact = (
         _get_index(repo.working_dir, file=True).get_index().state[name]
     )  # pylint: disable=protected-access
-    _check_obj(
+    check_obj(
         artifact,
         dict(
             type="new-type",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -280,40 +280,6 @@ def test_tag_untag(repo_with_commit: Tuple[git.Repo, Callable]):
     )
 
 
-def test_tag2(repo_with_commit: Tuple[git.Repo, Callable]):
-    repo, write_file = repo_with_commit
-    _check_successful_cmd(
-        "tag2",
-        ["-r", repo.working_dir, "x1"],
-        "Created git tag 'x1@v0.0.1'\n",
-    )
-    _check_successful_cmd(
-        "tag2",
-        ["-r", repo.working_dir, "x2", "HEAD"],
-        "Created git tag 'x2@v0.0.1'\n",
-    )
-    _check_successful_cmd(
-        "tag2",
-        ["-r", repo.working_dir, "x3", repo.commit().hexsha],
-        "Created git tag 'x3@v0.0.1'\n",
-    )
-    _check_successful_cmd(
-        "tag2",
-        ["-r", repo.working_dir, "x3", repo.commit().hexsha, "prod"],
-        "Created git tag 'x3#prod#1'\n",
-    )
-    _check_successful_cmd(
-        "tag2",
-        ["-r", repo.working_dir, "x3", "v0.0.1", "dev"],
-        "Created git tag 'x3#dev#2'\n",
-    )
-    _check_successful_cmd(
-        "tag2",
-        ["-r", repo.working_dir, "x4", repo.commit().hexsha, "v1.0.0"],
-        "Created git tag 'x4@v1.0.0'\n",
-    )
-
-
 EXPECTED_DESCRIBE_OUTPUT_2 = """{
     "type": "new-type",
     "path": "new/path",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -118,12 +118,12 @@ def test_commands(showcase):
     )
     _check_successful_cmd(
         "which",
-        ["-r", path, "rf", "production", "--all"],
+        ["-r", path, "rf", "production", "--vs", "-1"],
         "v1.2.4\nv1.2.3\n",
     )
     _check_successful_cmd(
         "which",
-        ["-r", path, "rf", "staging", "--all"],
+        ["-r", path, "rf", "staging", "--vs", "-1"],
         "v1.2.4\n",
     )
     _check_successful_cmd(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -75,7 +75,6 @@ def test_register_incorrect_name(init_repo):
         register(init_repo, "###", ref="HEAD")
 
 
-@pytest.mark.xfail
 def test_register_incorrect_version(init_repo):
     with pytest.raises(ValidationError):
         register(init_repo, "model", ref="HEAD", version="###")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -8,7 +8,7 @@ from typer.testing import CliRunner
 from gto.api import annotate, assign, get_stages, register
 from gto.cli import app
 from gto.config import CONFIG_FILE_NAME, check_name_is_valid
-from gto.exceptions import UnknownType, ValidationError
+from gto.exceptions import InvalidTagName, UnknownType, ValidationError
 from gto.index import init_index_manager
 from gto.registry import GitRegistry
 
@@ -28,6 +28,8 @@ def init_repo(empty_git_repo: Tuple[git.Repo, Callable]):
     repo, write_file = empty_git_repo
 
     write_file(CONFIG_FILE_NAME, CONFIG_CONTENT)
+    repo.index.add([CONFIG_FILE_NAME])
+    repo.index.commit("Initial commit")
     return repo
 
 
@@ -76,7 +78,7 @@ def test_register_incorrect_name(init_repo):
 
 
 def test_register_incorrect_version(init_repo):
-    with pytest.raises(ValidationError):
+    with pytest.raises(InvalidTagName):
         register(init_repo, "model", ref="HEAD", version="###")
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -5,7 +5,7 @@ import git
 import pytest
 from typer.testing import CliRunner
 
-from gto.api import annotate, get_stages, promote, register
+from gto.api import annotate, assign, get_stages, register
 from gto.cli import app
 from gto.config import CONFIG_FILE_NAME, check_name_is_valid
 from gto.exceptions import UnknownType, ValidationError
@@ -81,14 +81,14 @@ def test_register_incorrect_version(init_repo):
         register(init_repo, "model", ref="HEAD", version="###")
 
 
-def test_promote_incorrect_name(init_repo):
+def test_assign_incorrect_name(init_repo):
     with pytest.raises(ValidationError):
-        promote(init_repo, "###", promote_ref="HEAD", stage="dev")
+        assign(init_repo, "###", ref="HEAD", stage="dev")
 
 
-def test_promote_incorrect_stage(init_repo):
+def test_assign_incorrect_stage(init_repo):
     with pytest.raises(ValidationError):
-        promote(init_repo, "model", promote_ref="HEAD", stage="###")
+        assign(init_repo, "model", ref="HEAD", stage="###")
 
 
 def test_config_is_not_needed(empty_git_repo: Tuple[git.Repo, Callable], request):
@@ -119,9 +119,9 @@ def test_prohibit_config_type(init_repo_prohibit):
 
 
 @pytest.mark.xfail
-def test_prohibit_config_promote_incorrect_stage(init_repo):
+def test_prohibit_config_assign_incorrect_stage(init_repo):
     with pytest.raises(ValidationError):
-        promote(init_repo, "model", promote_ref="HEAD", stage="dev")
+        assign(init_repo, "model", ref="HEAD", stage="dev")
 
 
 def test_empty_config_type(empty_git_repo):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -9,7 +9,7 @@ from gto.api import annotate, assign, get_stages, register
 from gto.cli import app
 from gto.config import CONFIG_FILE_NAME, check_name_is_valid
 from gto.exceptions import (
-    InvalidTagName,
+    InvalidVersion,
     UnknownStage,
     UnknownType,
     ValidationError,
@@ -91,7 +91,7 @@ def test_register_incorrect_name(init_repo):
 
 
 def test_register_incorrect_version(init_repo):
-    with pytest.raises(InvalidTagName):
+    with pytest.raises(InvalidVersion):
         register(init_repo, "model", ref="HEAD", version="###")
 
 

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -16,7 +16,7 @@ EXPECTED_REGISTRY_TAG_TAG_STATE = {
                     "commit_hexsha": "d1d973669cade722f2900e75379cee42fe6b0244",
                     "discovered": False,
                     "tag": "nn@v0.0.1",
-                    "promotions": [
+                    "assignments": [
                         {
                             "artifact": "nn",
                             "version": "v0.0.1",
@@ -55,7 +55,7 @@ EXPECTED_REGISTRY_TAG_TAG_STATE = {
                     "commit_hexsha": "d1d973669cade722f2900e75379cee42fe6b0244",
                     "discovered": False,
                     "tag": "rf@v1.2.3",
-                    "promotions": [
+                    "assignments": [
                         {
                             "artifact": "rf",
                             "version": "v1.2.3",
@@ -100,7 +100,7 @@ EXPECTED_REGISTRY_TAG_TAG_STATE = {
                     "commit_hexsha": "16b7b77f1219ea3c10ae5beeb8473fb49cbd8c13",
                     "discovered": False,
                     "tag": "rf@v1.2.4",
-                    "promotions": [
+                    "assignments": [
                         {
                             "artifact": "rf",
                             "version": "v1.2.4",
@@ -172,8 +172,8 @@ def _check_state(appread_state, expected_state, exclude):
             appread_state["artifacts"][name]["versions"],
             expected_state["artifacts"][name]["versions"],
         ):
-            for a, e in zip(appeared["promotions"], expected["promotions"]):
-                _check_dict(a, e, exclude["promotions"])
+            for a, e in zip(appeared["assignments"], expected["assignments"]):
+                _check_dict(a, e, exclude["assignments"])
 
 
 def test_registry_state_tag_tag(showcase):
@@ -189,11 +189,11 @@ def test_registry_state_tag_tag(showcase):
             "author_email",
             "created_at",
             "commit_hexsha",
-            "promotions",
+            "assignments",
             "enrichments",
             "message",
         ],
-        "promotions": [
+        "assignments": [
             "author",
             "author_email",
             "created_at",

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1,7 +1,7 @@
 # pylint: disable=unused-variable
 from gto.registry import GitRegistry
 
-from .utils import _check_dict
+from .utils import check_obj
 
 EXPECTED_REGISTRY_TAG_TAG_STATE = {
     "artifacts": {
@@ -167,13 +167,13 @@ def _check_state(appread_state, expected_state, exclude):
                 iter_over(appread_state["artifacts"][name][part]),
                 iter_over(expected_state["artifacts"][name][part]),
             ):
-                _check_dict(appeared, expected, exclude[part])
+                check_obj(appeared, expected, exclude[part])
         for appeared, expected in zip(
             appread_state["artifacts"][name]["versions"],
             expected_state["artifacts"][name]["versions"],
         ):
             for a, e in zip(appeared["assignments"], expected["assignments"]):
-                _check_dict(a, e, exclude["assignments"])
+                check_obj(a, e, exclude["assignments"])
 
 
 def test_registry_state_tag_tag(showcase):

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -383,6 +383,8 @@ def test_registry_state_tag_tag(showcase):
             "commit_hexsha",
             "message",
             "version",
+            "committer",
+            "committer_email",
         ],
         "registrations": [
             "author",

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1,152 +1,348 @@
-# pylint: disable=unused-variable
+# pylint: disable=unused-variable, too-many-locals
 from gto.registry import GitRegistry
 
 from .utils import check_obj
 
 EXPECTED_REGISTRY_TAG_TAG_STATE = {
     "artifacts": {
+        "rf": {
+            "artifact": "rf",
+            "versions": [
+                {
+                    "artifact": "rf",
+                    "commit_hexsha": "89de382074d472f8e6b8fd654490183c3c0fb497",
+                    "version": "v1.2.3",
+                    "enrichments": [
+                        {
+                            "priority": 0,
+                            "addition": True,
+                            "artifact": "rf",
+                            "created_at": "2022-08-04T16:56:57",
+                            "author": "Alexander Guschin",
+                            "author_email": "1aguschin@gmail.com",
+                            "message": "Add artifacts",
+                            "commit_hexsha": "89de382074d472f8e6b8fd654490183c3c0fb497",
+                            "version": "v1.2.3",
+                            "enrichments": [
+                                {
+                                    "source": "gto",
+                                    "artifact": {
+                                        "type": "model",
+                                        "path": "models/random-forest.pkl",
+                                        "virtual": False,
+                                        "labels": [],
+                                        "description": "",
+                                    },
+                                }
+                            ],
+                            "committer": "Alexander Guschin",
+                            "committer_email": "1aguschin@gmail.com",
+                        }
+                    ],
+                    "registrations": [
+                        {
+                            "priority": 3,
+                            "addition": True,
+                            "artifact": "rf",
+                            "created_at": "2022-08-04T16:56:57",
+                            "author": "Alexander Guschin",
+                            "author_email": "1aguschin@gmail.com",
+                            "message": "Registering artifact rf version v1.2.3",
+                            "commit_hexsha": "89de382074d472f8e6b8fd654490183c3c0fb497",
+                            "tag": "rf@v1.2.3",
+                            "version": "v1.2.3",
+                        }
+                    ],
+                    "deregistrations": [],
+                    "stages": {
+                        "production": {
+                            "artifact": "rf",
+                            "commit_hexsha": "89de382074d472f8e6b8fd654490183c3c0fb497",
+                            "version": "v1.2.3",
+                            "stage": "production",
+                            "assignments": [
+                                {
+                                    "priority": 5,
+                                    "addition": True,
+                                    "artifact": "rf",
+                                    "created_at": "2022-08-04T16:56:59",
+                                    "author": "Alexander Guschin",
+                                    "author_email": "1aguschin@gmail.com",
+                                    "message": "Assigning stage production to artifact rf version v1.2.3",
+                                    "commit_hexsha": "89de382074d472f8e6b8fd654490183c3c0fb497",
+                                    "tag": "rf#production#1",
+                                    "version": "v1.2.3",
+                                    "stage": "production",
+                                },
+                                {
+                                    "priority": 5,
+                                    "addition": True,
+                                    "artifact": "rf",
+                                    "created_at": "2022-08-04T16:57:02",
+                                    "author": "Alexander Guschin",
+                                    "author_email": "1aguschin@gmail.com",
+                                    "message": "Assigning stage production to artifact rf version v1.2.3",
+                                    "commit_hexsha": "89de382074d472f8e6b8fd654490183c3c0fb497",
+                                    "tag": "rf#production#4",
+                                    "version": "v1.2.3",
+                                    "stage": "production",
+                                },
+                            ],
+                            "unassignments": [],
+                        }
+                    },
+                },
+                {
+                    "artifact": "rf",
+                    "commit_hexsha": "04d79900801d9aa7ec726169706280a32a25d198",
+                    "version": "v1.2.4",
+                    "enrichments": [
+                        {
+                            "priority": 0,
+                            "addition": True,
+                            "artifact": "rf",
+                            "created_at": "2022-08-04T16:56:59",
+                            "author": "Alexander Guschin",
+                            "author_email": "1aguschin@gmail.com",
+                            "message": "Update model",
+                            "commit_hexsha": "04d79900801d9aa7ec726169706280a32a25d198",
+                            "version": "v1.2.4",
+                            "enrichments": [
+                                {
+                                    "source": "gto",
+                                    "artifact": {
+                                        "type": "model",
+                                        "path": "models/random-forest.pkl",
+                                        "virtual": False,
+                                        "labels": [],
+                                        "description": "",
+                                    },
+                                }
+                            ],
+                            "committer": "Alexander Guschin",
+                            "committer_email": "1aguschin@gmail.com",
+                        }
+                    ],
+                    "registrations": [
+                        {
+                            "priority": 3,
+                            "addition": True,
+                            "artifact": "rf",
+                            "created_at": "2022-08-04T16:56:59",
+                            "author": "Alexander Guschin",
+                            "author_email": "1aguschin@gmail.com",
+                            "message": "Registering artifact rf version v1.2.4",
+                            "commit_hexsha": "04d79900801d9aa7ec726169706280a32a25d198",
+                            "tag": "rf@v1.2.4",
+                            "version": "v1.2.4",
+                        }
+                    ],
+                    "deregistrations": [],
+                    "stages": {
+                        "staging": {
+                            "artifact": "rf",
+                            "commit_hexsha": "04d79900801d9aa7ec726169706280a32a25d198",
+                            "version": "v1.2.4",
+                            "stage": "staging",
+                            "assignments": [
+                                {
+                                    "priority": 5,
+                                    "addition": True,
+                                    "artifact": "rf",
+                                    "created_at": "2022-08-04T16:57:00",
+                                    "author": "Alexander Guschin",
+                                    "author_email": "1aguschin@gmail.com",
+                                    "message": "Assigning stage staging to artifact rf version v1.2.4",
+                                    "commit_hexsha": "04d79900801d9aa7ec726169706280a32a25d198",
+                                    "tag": "rf#staging#2",
+                                    "version": "v1.2.4",
+                                    "stage": "staging",
+                                }
+                            ],
+                            "unassignments": [],
+                        },
+                        "production": {
+                            "artifact": "rf",
+                            "commit_hexsha": "04d79900801d9aa7ec726169706280a32a25d198",
+                            "version": "v1.2.4",
+                            "stage": "production",
+                            "assignments": [
+                                {
+                                    "priority": 5,
+                                    "addition": True,
+                                    "artifact": "rf",
+                                    "created_at": "2022-08-04T16:57:01",
+                                    "author": "Alexander Guschin",
+                                    "author_email": "1aguschin@gmail.com",
+                                    "message": "Assigning stage production to artifact rf version v1.2.4",
+                                    "commit_hexsha": "04d79900801d9aa7ec726169706280a32a25d198",
+                                    "tag": "rf#production#3",
+                                    "version": "v1.2.4",
+                                    "stage": "production",
+                                }
+                            ],
+                            "unassignments": [],
+                        },
+                    },
+                },
+            ],
+            "creations": [],
+            "deprecations": [],
+        },
         "nn": {
+            "artifact": "nn",
             "versions": [
                 {
                     "artifact": "nn",
-                    "name": "v0.0.1",
-                    "created_at": "2022-04-11T21:51:56",
-                    "author": "Alexander Guschin",
-                    "author_email": "1aguschin@gmail.com",
-                    "commit_hexsha": "d1d973669cade722f2900e75379cee42fe6b0244",
-                    "discovered": False,
-                    "tag": "nn@v0.0.1",
-                    "assignments": [
+                    "commit_hexsha": "89de382074d472f8e6b8fd654490183c3c0fb497",
+                    "version": "v0.0.1",
+                    "enrichments": [
                         {
+                            "priority": 0,
+                            "addition": True,
                             "artifact": "nn",
+                            "created_at": "2022-08-04T16:56:57",
+                            "author": "Alexander Guschin",
+                            "author_email": "1aguschin@gmail.com",
+                            "message": "Add artifacts",
+                            "commit_hexsha": "89de382074d472f8e6b8fd654490183c3c0fb497",
+                            "version": "v0.0.1",
+                            "enrichments": [
+                                {
+                                    "source": "gto",
+                                    "artifact": {
+                                        "type": "model",
+                                        "path": "models/neural-network.pkl",
+                                        "virtual": False,
+                                        "labels": [],
+                                        "description": "",
+                                    },
+                                }
+                            ],
+                            "committer": "Alexander Guschin",
+                            "committer_email": "1aguschin@gmail.com",
+                        }
+                    ],
+                    "registrations": [
+                        {
+                            "priority": 3,
+                            "addition": True,
+                            "artifact": "nn",
+                            "created_at": "2022-08-04T16:56:58",
+                            "author": "Alexander Guschin",
+                            "author_email": "1aguschin@gmail.com",
+                            "message": "Registering artifact nn version v0.0.1",
+                            "commit_hexsha": "89de382074d472f8e6b8fd654490183c3c0fb497",
+                            "tag": "nn@v0.0.1",
+                            "version": "v0.0.1",
+                        }
+                    ],
+                    "deregistrations": [],
+                    "stages": {
+                        "staging": {
+                            "artifact": "nn",
+                            "commit_hexsha": "89de382074d472f8e6b8fd654490183c3c0fb497",
                             "version": "v0.0.1",
                             "stage": "staging",
-                            "created_at": "2022-04-11T21:51:57",
-                            "author": "Alexander Guschin",
-                            "author_email": "1aguschin@gmail.com",
-                            "commit_hexsha": "d1d973669cade722f2900e75379cee42fe6b0244",
-                            "tag": "nn#staging#1",
+                            "assignments": [
+                                {
+                                    "priority": 5,
+                                    "addition": True,
+                                    "artifact": "nn",
+                                    "created_at": "2022-08-04T16:56:59",
+                                    "author": "Alexander Guschin",
+                                    "author_email": "1aguschin@gmail.com",
+                                    "message": "Assigning stage staging to artifact nn version v0.0.1",
+                                    "commit_hexsha": "89de382074d472f8e6b8fd654490183c3c0fb497",
+                                    "tag": "nn#staging#1",
+                                    "version": "v0.0.1",
+                                    "stage": "staging",
+                                }
+                            ],
+                            "unassignments": [],
                         }
-                    ],
+                    },
+                },
+                {
+                    "artifact": "nn",
+                    "commit_hexsha": "04d79900801d9aa7ec726169706280a32a25d198",
+                    "version": "04d79900801d9aa7ec726169706280a32a25d198",
                     "enrichments": [
                         {
-                            "source": "gto",
-                            "artifact": {
-                                "type": "model",
-                                "name": "nn",
-                                "path": "models/neural-network.pkl",
-                                "virtual": False,
-                                "labels": [],
-                                "description": "",
-                            },
+                            "priority": 0,
+                            "addition": True,
+                            "artifact": "nn",
+                            "created_at": "2022-08-04T16:56:59",
+                            "author": "Alexander Guschin",
+                            "author_email": "1aguschin@gmail.com",
+                            "message": "Update model",
+                            "commit_hexsha": "04d79900801d9aa7ec726169706280a32a25d198",
+                            "version": "04d79900801d9aa7ec726169706280a32a25d198",
+                            "enrichments": [
+                                {
+                                    "source": "gto",
+                                    "artifact": {
+                                        "type": "model",
+                                        "path": "models/neural-network.pkl",
+                                        "virtual": False,
+                                        "labels": [],
+                                        "description": "",
+                                    },
+                                }
+                            ],
+                            "committer": "Alexander Guschin",
+                            "committer_email": "1aguschin@gmail.com",
                         }
                     ],
-                }
+                    "registrations": [],
+                    "deregistrations": [],
+                    "stages": {},
+                },
             ],
+            "creations": [],
+            "deprecations": [],
         },
-        "rf": {
+        "features": {
+            "artifact": "features",
             "versions": [
                 {
-                    "artifact": "rf",
-                    "name": "v1.2.3",
-                    "created_at": "2022-04-11T21:51:56",
-                    "author": "Alexander Guschin",
-                    "author_email": "1aguschin@gmail.com",
-                    "commit_hexsha": "d1d973669cade722f2900e75379cee42fe6b0244",
-                    "discovered": False,
-                    "tag": "rf@v1.2.3",
-                    "assignments": [
-                        {
-                            "artifact": "rf",
-                            "version": "v1.2.3",
-                            "stage": "production",
-                            "created_at": "2022-04-11T21:51:57",
-                            "author": "Alexander Guschin",
-                            "author_email": "1aguschin@gmail.com",
-                            "commit_hexsha": "d1d973669cade722f2900e75379cee42fe6b0244",
-                            "tag": "rf#production#1",
-                        },
-                        {
-                            "artifact": "rf",
-                            "version": "v1.2.3",
-                            "stage": "production",
-                            "created_at": "2022-04-11T21:52:01",
-                            "author": "Alexander Guschin",
-                            "author_email": "1aguschin@gmail.com",
-                            "commit_hexsha": "d1d973669cade722f2900e75379cee42fe6b0244",
-                            "tag": "rf#production#4",
-                        },
-                    ],
+                    "artifact": "features",
+                    "commit_hexsha": "04d79900801d9aa7ec726169706280a32a25d198",
+                    "version": "04d79900801d9aa7ec726169706280a32a25d198",
                     "enrichments": [
                         {
-                            "source": "gto",
-                            "artifact": {
-                                "type": "model",
-                                "name": "rf",
-                                "path": "models/random-forest.pkl",
-                                "virtual": False,
-                                "labels": [],
-                                "description": "",
-                            },
+                            "priority": 0,
+                            "addition": True,
+                            "artifact": "features",
+                            "created_at": "2022-08-04T16:56:59",
+                            "author": "Alexander Guschin",
+                            "author_email": "1aguschin@gmail.com",
+                            "message": "Update model",
+                            "commit_hexsha": "04d79900801d9aa7ec726169706280a32a25d198",
+                            "version": "04d79900801d9aa7ec726169706280a32a25d198",
+                            "enrichments": [
+                                {
+                                    "source": "gto",
+                                    "artifact": {
+                                        "type": "dataset",
+                                        "path": "datasets/features.csv",
+                                        "virtual": True,
+                                        "labels": [],
+                                        "description": "",
+                                    },
+                                }
+                            ],
+                            "committer": "Alexander Guschin",
+                            "committer_email": "1aguschin@gmail.com",
                         }
                     ],
-                },
-                {
-                    "artifact": "rf",
-                    "name": "v1.2.4",
-                    "created_at": "2022-04-12T19:03:44",
-                    "author": "Alexander Guschin",
-                    "author_email": "1aguschin@gmail.com",
-                    "commit_hexsha": "16b7b77f1219ea3c10ae5beeb8473fb49cbd8c13",
-                    "discovered": False,
-                    "tag": "rf@v1.2.4",
-                    "assignments": [
-                        {
-                            "artifact": "rf",
-                            "version": "v1.2.4",
-                            "stage": "staging",
-                            "created_at": "2022-04-11T21:51:58",
-                            "author": "Alexander Guschin",
-                            "author_email": "1aguschin@gmail.com",
-                            "commit_hexsha": "16b7b77f1219ea3c10ae5beeb8473fb49cbd8c13",
-                            "tag": "rf#staging#2",
-                        },
-                        {
-                            "artifact": "rf",
-                            "version": "v1.2.4",
-                            "stage": "production",
-                            "created_at": "2022-04-11T21:51:59",
-                            "author": "Alexander Guschin",
-                            "author_email": "1aguschin@gmail.com",
-                            "commit_hexsha": "16b7b77f1219ea3c10ae5beeb8473fb49cbd8c13",
-                            "tag": "rf#production#3",
-                        },
-                        {
-                            "artifact": "rf",
-                            "version": "v1.2.4",
-                            "stage": "stagegeg",
-                            "created_at": "2022-04-12T19:26:08",
-                            "author": "Alexander Guschin",
-                            "author_email": "1aguschin@gmail.com",
-                            "commit_hexsha": "16b7b77f1219ea3c10ae5beeb8473fb49cbd8c13",
-                            "tag": "rf#stagegeg#5",
-                        },
-                    ],
-                    "enrichments": [
-                        {
-                            "source": "gto",
-                            "artifact": {
-                                "type": "model",
-                                "name": "rf",
-                                "path": "models/random-forest.pkl",
-                                "virtual": False,
-                                "labels": [],
-                                "description": "",
-                            },
-                        }
-                    ],
-                },
+                    "registrations": [],
+                    "deregistrations": [],
+                    "stages": {},
+                }
             ],
+            "creations": [],
+            "deprecations": [],
         },
     }
 }
@@ -160,26 +356,10 @@ def iter_over(sequence):
     raise NotImplementedError
 
 
-def _check_state(appread_state, expected_state, exclude):
-    for name in expected_state["artifacts"]:
-        for part in ["versions"]:  # "commits"
-            for appeared, expected in zip(
-                iter_over(appread_state["artifacts"][name][part]),
-                iter_over(expected_state["artifacts"][name][part]),
-            ):
-                check_obj(appeared, expected, exclude[part])
-        for appeared, expected in zip(
-            appread_state["artifacts"][name]["versions"],
-            expected_state["artifacts"][name]["versions"],
-        ):
-            for a, e in zip(appeared["assignments"], expected["assignments"]):
-                check_obj(a, e, exclude["assignments"])
-
-
 def test_registry_state_tag_tag(showcase):
     path, repo, write_file, first_commit, second_commit = showcase
     reg = GitRegistry.from_repo(repo)
-    state = reg.get_state().dict()
+    appeared_state = reg.get_state().dict()
 
     # TODO: update state
     exclude = {
@@ -189,17 +369,66 @@ def test_registry_state_tag_tag(showcase):
             "author_email",
             "created_at",
             "commit_hexsha",
-            "assignments",
+            "registrations",
+            "deregistrations",
             "enrichments",
+            "stages",
             "message",
+            "version",
         ],
-        "assignments": [
+        "enrichments": [
             "author",
             "author_email",
             "created_at",
             "commit_hexsha",
             "message",
+            "version",
+        ],
+        "registrations": [
+            "author",
+            "author_email",
+            "created_at",
+            "commit_hexsha",
+            "message",
+            "version",
+        ],
+        "deregistrations": [
+            "author",
+            "author_email",
+            "created_at",
+            "commit_hexsha",
+            "message",
+            "version",
+        ],
+        "stages": [
+            "author",
+            "author_email",
+            "created_at",
+            "commit_hexsha",
+            "message",
+            "version",
+            "assignments",
+            "unassignments",
         ],
     }
 
-    _check_state(state, EXPECTED_REGISTRY_TAG_TAG_STATE, exclude)
+    expected_state = EXPECTED_REGISTRY_TAG_TAG_STATE
+    for artifact in expected_state["artifacts"]:
+
+        for appeared, expected in zip(
+            iter_over(appeared_state["artifacts"][artifact]["versions"]),
+            iter_over(expected_state["artifacts"][artifact]["versions"]),
+        ):
+            check_obj(appeared, expected, exclude["versions"])
+
+            for key in ["enrichments", "registrations", "deregistrations"]:
+                for a, e in zip(
+                    iter_over(appeared[key]),
+                    iter_over(expected[key]),
+                ):
+                    check_obj(a, e, exclude[key])
+
+            for key in appeared["stages"]:
+                check_obj(
+                    appeared["stages"][key], expected["stages"][key], exclude["stages"]
+                )

--- a/tests/test_showcase.py
+++ b/tests/test_showcase.py
@@ -69,8 +69,8 @@ def test_api(showcase):
         ),
         skip_keys=skip_keys_registration,
     )
-    assert len(nn_artifact.get_stages()) == 1
-    nn_vstage = nn_artifact.get_stages()
+    assert len(nn_artifact.get_vstages()) == 1
+    nn_vstage = nn_artifact.get_vstages()
     assert isinstance(nn_vstage, VStage)
     check_obj(
         nn_vstage,

--- a/tests/test_showcase.py
+++ b/tests/test_showcase.py
@@ -158,4 +158,6 @@ def test_api(showcase):
         ),
         skip_keys=skip_keys_assignment,
     )
-    assert gto.api.find_versions_in_stage(repo, "rf", "staging", all=True) == [rf_l3]
+    assert gto.api.find_versions_in_stage(
+        repo, "rf", "staging", versions_per_stage=-1
+    ) == [rf_l3]

--- a/tests/test_showcase.py
+++ b/tests/test_showcase.py
@@ -148,7 +148,6 @@ def test_api(showcase):
         isinstance(p, (Assignment, Unassignment, Commit))
         for p in rf_ver1.get_events(direct=False) + rf_ver2.get_events(direct=False)
     )
-    print(rf_ver2.get_events(direct=False))
     rf_a4, rf_a1, rf_c1 = rf_ver1.get_events(
         direct=False
     )  # pylint: disable=unused-variable

--- a/tests/test_showcase.py
+++ b/tests/test_showcase.py
@@ -1,7 +1,7 @@
 """TODO: break this file into multiple test/files"""
 # pylint: disable=unused-variable, too-many-locals, too-many-statements
 import gto
-from gto.base import BaseArtifact, BaseAssignment, BaseVersion
+from gto.base import Artifact, Assignment, Version
 from tests.utils import _check_obj
 
 
@@ -29,11 +29,11 @@ def test_api(showcase):
     #     ["commits"],
     # )
     nn_artifact = artifacts["nn"]
-    assert isinstance(nn_artifact, BaseArtifact)
-    assert nn_artifact.name == "nn"
+    assert isinstance(nn_artifact, Artifact)
+    assert nn_artifact.artifact == "nn"
     assert len(nn_artifact.versions) == 2
     nn_version = nn_artifact.versions[0]
-    assert isinstance(nn_version, BaseVersion)
+    assert isinstance(nn_version, Version)
     author = repo.commit().author.name
     author_email = repo.commit().author.email
 
@@ -58,9 +58,9 @@ def test_api(showcase):
         ),
         skip_keys=skip_keys_registration,
     )
-    assert len(nn_artifact.stages) == 1
-    nn_assignment = nn_artifact.stages[0]
-    assert isinstance(nn_assignment, BaseAssignment)
+    assert len(nn_artifact.assignments) == 1
+    nn_assignment = nn_artifact.assignments[0]
+    assert isinstance(nn_assignment, Assignment)
     _check_obj(
         nn_assignment,
         dict(
@@ -75,11 +75,11 @@ def test_api(showcase):
     )
 
     rf_artifact = artifacts["rf"]
-    assert isinstance(rf_artifact, BaseArtifact)
-    assert rf_artifact.name == "rf"
+    assert isinstance(rf_artifact, Artifact)
+    assert rf_artifact.artifact == "rf"
 
     assert len(rf_artifact.versions) == 2
-    assert all(isinstance(v, BaseVersion) for v in rf_artifact.versions)
+    assert all(isinstance(v, Version) for v in rf_artifact.versions)
     rf_ver1, rf_ver2 = rf_artifact.versions
     _check_obj(
         rf_ver1,
@@ -106,8 +106,8 @@ def test_api(showcase):
         skip_keys=skip_keys_registration,
     )
 
-    assert len(rf_artifact.stages) == 4
-    assert all(isinstance(p, BaseAssignment) for p in rf_artifact.stages)
+    assert len(rf_artifact.assignments) == 4
+    assert all(isinstance(p, Assignment) for p in rf_artifact.assignments)
     rf_l1, _ = rf_ver1.assignments
     rf_l3, rf_l4 = rf_ver2.assignments
 

--- a/tests/test_showcase.py
+++ b/tests/test_showcase.py
@@ -1,8 +1,8 @@
 """TODO: break this file into multiple test/files"""
 # pylint: disable=unused-variable, too-many-locals, too-many-statements
 import gto
-from gto.base import Artifact, Assignment, Version
-from tests.utils import _check_obj
+from gto.base import Artifact, Assignment, Version, VStage
+from tests.utils import check_obj
 
 
 def test_api(showcase):
@@ -39,30 +39,41 @@ def test_api(showcase):
 
     skip_keys_registration = {
         "created_at",
-        "assignments",
+        "activated_at",
+        "registrations",
+        "deregistrations",
         "enrichments",
         "tag",
         "message",
+        "stages",
     }
-    skip_keys_assignment = {"created_at", "tag", "message"}
+    skip_keys_assignment = {
+        "created_at",
+        "tag",
+        "message",
+        "assignments",
+        "unassignments",
+    }
 
-    _check_obj(
-        nn_version,
+    check_obj(
+        nn_version.dict_state(),
         dict(
             artifact="nn",
-            name="v0.0.1",
+            version="v0.0.1",
             author=author,
             author_email=author_email,
             commit_hexsha=first_commit.hexsha,
             discovered=False,
+            is_active=True,
+            ref="nn@v0.0.1",
         ),
         skip_keys=skip_keys_registration,
     )
-    assert len(nn_artifact.assignments) == 1
-    nn_assignment = nn_artifact.assignments[0]
-    assert isinstance(nn_assignment, Assignment)
-    _check_obj(
-        nn_assignment,
+    assert len(nn_artifact.get_stages()) == 1
+    nn_vstage = nn_artifact.get_stages()
+    assert isinstance(nn_vstage, VStage)
+    check_obj(
+        nn_vstage,
         dict(
             artifact="nn",
             version="v0.0.1",
@@ -81,7 +92,7 @@ def test_api(showcase):
     assert len(rf_artifact.versions) == 2
     assert all(isinstance(v, Version) for v in rf_artifact.versions)
     rf_ver1, rf_ver2 = rf_artifact.versions
-    _check_obj(
+    check_obj(
         rf_ver1,
         dict(
             artifact="rf",
@@ -93,7 +104,7 @@ def test_api(showcase):
         ),
         skip_keys=skip_keys_registration,
     )
-    _check_obj(
+    check_obj(
         rf_ver2,
         dict(
             artifact="rf",
@@ -111,7 +122,7 @@ def test_api(showcase):
     rf_l1, _ = rf_ver1.assignments
     rf_l3, rf_l4 = rf_ver2.assignments
 
-    _check_obj(
+    check_obj(
         rf_l1,
         dict(
             artifact="rf",
@@ -123,7 +134,7 @@ def test_api(showcase):
         ),
         skip_keys=skip_keys_assignment,
     )
-    _check_obj(
+    check_obj(
         rf_l4,
         dict(
             artifact="rf",
@@ -135,7 +146,7 @@ def test_api(showcase):
         ),
         skip_keys=skip_keys_assignment,
     )
-    _check_obj(
+    check_obj(
         rf_l3,
         dict(
             artifact="rf",

--- a/tests/test_showcase.py
+++ b/tests/test_showcase.py
@@ -1,7 +1,7 @@
 """TODO: break this file into multiple test/files"""
 # pylint: disable=unused-variable, too-many-locals, too-many-statements
 import gto
-from gto.base import BaseArtifact, BasePromotion, BaseVersion
+from gto.base import BaseArtifact, BaseAssignment, BaseVersion
 from tests.utils import _check_obj
 
 
@@ -13,6 +13,12 @@ def test_api(showcase):
         first_commit,
         second_commit,
     ) = showcase
+
+    gto.api.show(repo)
+    gto.api.history(repo)
+    for name in "nn", "rf", "features":
+        gto.api.show(repo, name)
+        gto.api.history(repo, name)
 
     artifacts = gto.api._get_state(path).artifacts  # pylint: disable=protected-access
     assert set(artifacts.keys()) == {"nn", "rf", "features"}
@@ -33,12 +39,12 @@ def test_api(showcase):
 
     skip_keys_registration = {
         "created_at",
-        "promotions",
+        "assignments",
         "enrichments",
         "tag",
         "message",
     }
-    skip_keys_promotion = {"created_at", "tag", "message"}
+    skip_keys_assignment = {"created_at", "tag", "message"}
 
     _check_obj(
         nn_version,
@@ -53,10 +59,10 @@ def test_api(showcase):
         skip_keys=skip_keys_registration,
     )
     assert len(nn_artifact.stages) == 1
-    nn_promotion = nn_artifact.stages[0]
-    assert isinstance(nn_promotion, BasePromotion)
+    nn_assignment = nn_artifact.stages[0]
+    assert isinstance(nn_assignment, BaseAssignment)
     _check_obj(
-        nn_promotion,
+        nn_assignment,
         dict(
             artifact="nn",
             version="v0.0.1",
@@ -65,7 +71,7 @@ def test_api(showcase):
             author_email=author_email,
             commit_hexsha=first_commit.hexsha,
         ),
-        skip_keys=skip_keys_promotion,
+        skip_keys=skip_keys_assignment,
     )
 
     rf_artifact = artifacts["rf"]
@@ -101,9 +107,9 @@ def test_api(showcase):
     )
 
     assert len(rf_artifact.stages) == 4
-    assert all(isinstance(p, BasePromotion) for p in rf_artifact.stages)
-    rf_l1, _ = rf_ver1.promotions
-    rf_l3, rf_l4 = rf_ver2.promotions
+    assert all(isinstance(p, BaseAssignment) for p in rf_artifact.stages)
+    rf_l1, _ = rf_ver1.assignments
+    rf_l3, rf_l4 = rf_ver2.assignments
 
     _check_obj(
         rf_l1,
@@ -115,7 +121,7 @@ def test_api(showcase):
             author_email=author_email,
             commit_hexsha=first_commit.hexsha,
         ),
-        skip_keys=skip_keys_promotion,
+        skip_keys=skip_keys_assignment,
     )
     _check_obj(
         rf_l4,
@@ -127,7 +133,7 @@ def test_api(showcase):
             author_email=author_email,
             commit_hexsha=second_commit.hexsha,
         ),
-        skip_keys=skip_keys_promotion,
+        skip_keys=skip_keys_assignment,
     )
     _check_obj(
         rf_l3,
@@ -139,5 +145,6 @@ def test_api(showcase):
             author_email=author_email,
             commit_hexsha=second_commit.hexsha,
         ),
-        skip_keys=skip_keys_promotion,
+        skip_keys=skip_keys_assignment,
     )
+    assert gto.api.find_versions_in_stage(repo, "rf", "staging", all=True) == [rf_l3]

--- a/tests/test_tag.py
+++ b/tests/test_tag.py
@@ -23,18 +23,28 @@ def test_name_tag(empty_git_repo):
         name_tag(Action.ASSIGN, "myartifact", repo=repo, stage="stage", simple=False)
         == f"myartifact{ActionSign[Action.ASSIGN]}stage{ActionSign[Action.ASSIGN]}1"
     )
+    assert (
+        name_tag(Action.UNASSIGN, "myartifact", repo=repo, stage="stage", simple=False)
+        == f"myartifact{ActionSign[Action.ASSIGN]}stage{ActionSign[Action.ASSIGN]}1!"
+    )
 
 
 def test_parse_name():
     assert parse_name(f"path{ActionSign[Action.REGISTER]}v1.2.3") == dict(
         name="path", version="v1.2.3", action=Action.REGISTER
     )
+
     assert parse_name(f"path{ActionSign[Action.ASSIGN]}stage") == dict(
         name="path", action=Action.ASSIGN, stage="stage"
     )
+
     assert parse_name(
         f"path{ActionSign[Action.ASSIGN]}stage{ActionSign[Action.ASSIGN]}1"
     ) == dict(name="path", action=Action.ASSIGN, stage="stage", number=1)
+
+    assert parse_name(
+        f"path{ActionSign[Action.ASSIGN]}stage{ActionSign[Action.ASSIGN]}2!"
+    ) == dict(name="path", action=Action.UNASSIGN, stage="stage", number=2)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_tag.py
+++ b/tests/test_tag.py
@@ -6,45 +6,59 @@ import pytest
 
 from gto.constants import Action
 from gto.exceptions import RefNotFound, TagExists
-from gto.tag import ActionSign, create_tag, find, name_tag, parse_name
+from gto.tag import create_tag, find, name_tag, parse_name
 
 
 def test_name_tag(empty_git_repo):
     repo, write_func = empty_git_repo
+    assert name_tag(Action.REGISTER, "myartifact", "v1", simple=True) == "myartifact@v1"
     assert (
-        name_tag(Action.REGISTER, "myartifact", "v1")
-        == f"myartifact{ActionSign[Action.REGISTER]}v1"
+        name_tag(Action.REGISTER, "myartifact", "v1", simple=False, repo=repo)
+        == "myartifact@v1#1"
+    )
+    assert (
+        name_tag(Action.DEREGISTER, "myartifact", "v1", simple=True) == "myartifact@v1!"
+    )
+    assert (
+        name_tag(Action.DEREGISTER, "myartifact", "v1", simple=False, repo=repo)
+        == "myartifact@v1!#1"
     )
     assert (
         name_tag(Action.ASSIGN, "myartifact", stage="stage", simple=True)
-        == f"myartifact{ActionSign[Action.ASSIGN]}stage"
+        == "myartifact#stage"
     )
     assert (
         name_tag(Action.ASSIGN, "myartifact", repo=repo, stage="stage", simple=False)
-        == f"myartifact{ActionSign[Action.ASSIGN]}stage{ActionSign[Action.ASSIGN]}1"
+        == "myartifact#stage#1"
     )
     assert (
         name_tag(Action.UNASSIGN, "myartifact", repo=repo, stage="stage", simple=False)
-        == f"myartifact{ActionSign[Action.ASSIGN]}stage{ActionSign[Action.ASSIGN]}1!"
+        == "myartifact#stage!#1"
     )
 
 
 def test_parse_name():
-    assert parse_name(f"path{ActionSign[Action.REGISTER]}v1.2.3") == dict(
+    assert parse_name("path@v1.2.3") == dict(
         name="path", version="v1.2.3", action=Action.REGISTER
     )
-
-    assert parse_name(f"path{ActionSign[Action.ASSIGN]}stage") == dict(
+    assert parse_name("path@v1.2.3#5") == dict(
+        name="path", version="v1.2.3", action=Action.REGISTER, counter=5
+    )
+    assert parse_name("path@v1.2.3!") == dict(
+        name="path", version="v1.2.3", action=Action.DEREGISTER
+    )
+    assert parse_name("path@v1.2.3!#2") == dict(
+        name="path", version="v1.2.3", action=Action.DEREGISTER, counter=2
+    )
+    assert parse_name("path#stage") == dict(
         name="path", action=Action.ASSIGN, stage="stage"
     )
-
-    assert parse_name(
-        f"path{ActionSign[Action.ASSIGN]}stage{ActionSign[Action.ASSIGN]}1"
-    ) == dict(name="path", action=Action.ASSIGN, stage="stage", number=1)
-
-    assert parse_name(
-        f"path{ActionSign[Action.ASSIGN]}stage{ActionSign[Action.ASSIGN]}2!"
-    ) == dict(name="path", action=Action.UNASSIGN, stage="stage", number=2)
+    assert parse_name("path#stage#1") == dict(
+        name="path", action=Action.ASSIGN, stage="stage", counter=1
+    )
+    assert parse_name("path#stage!#2") == dict(
+        name="path", action=Action.UNASSIGN, stage="stage", counter=2
+    )
 
 
 @pytest.mark.parametrize(
@@ -54,6 +68,7 @@ def test_parse_name():
         "###",
         "@@@",
         "model@v1",
+        "nn#prod#-1",
         "model@v111",
         "model-prod",
         "model@0.0.1",
@@ -61,6 +76,8 @@ def test_parse_name():
         "model#prod#-1",
         "model#prod#1-2",
         "model#prod?#1-2",
+        "model#prod@v1.2.3",
+        "model@v1.2.3#prod",
         "model-prod-v1-stage",
         "model@prod@v1@stage-1",
         "namespace/model@0.0.1",
@@ -72,6 +89,28 @@ def test_parse_name():
 )
 def test_parse_wrong_names(tag_name):
     assert not parse_name(tag_name, raise_on_fail=False)
+
+
+@pytest.mark.parametrize(
+    "tag_name",
+    [
+        "nn#prod",
+        "nn#prod!",
+        "nn#prod#1",
+        "nn@v1.0.0",
+        "nn#prod!#2",
+        "nn@v1.0.0!",
+        "nn@v1.0.0#1",
+        "nn@v1.0.0!#1",
+        "nn@v1.0.0-rc.2",
+        "nn@v1.0.0-alpha",
+        "nn@v1.0.0-alpha.1",
+        "nn@v1.0.0-alpha.beta",
+        "new-artifact@v1.0.1!",
+    ],
+)
+def test_parse_correct_names(tag_name):
+    assert parse_name(tag_name, raise_on_fail=False)
 
 
 def test_create_tag_bad_ref(repo_with_commit):

--- a/tests/test_tag.py
+++ b/tests/test_tag.py
@@ -16,12 +16,12 @@ def test_name_tag(empty_git_repo):
         == f"myartifact{ActionSign[Action.REGISTER]}v1"
     )
     assert (
-        name_tag(Action.PROMOTE, "myartifact", stage="stage", simple=True)
-        == f"myartifact{ActionSign[Action.PROMOTE]}stage"
+        name_tag(Action.ASSIGN, "myartifact", stage="stage", simple=True)
+        == f"myartifact{ActionSign[Action.ASSIGN]}stage"
     )
     assert (
-        name_tag(Action.PROMOTE, "myartifact", repo=repo, stage="stage", simple=False)
-        == f"myartifact{ActionSign[Action.PROMOTE]}stage{ActionSign[Action.PROMOTE]}1"
+        name_tag(Action.ASSIGN, "myartifact", repo=repo, stage="stage", simple=False)
+        == f"myartifact{ActionSign[Action.ASSIGN]}stage{ActionSign[Action.ASSIGN]}1"
     )
 
 
@@ -29,12 +29,12 @@ def test_parse_name():
     assert parse_name(f"path{ActionSign[Action.REGISTER]}v1.2.3") == dict(
         name="path", version="v1.2.3", action=Action.REGISTER
     )
-    assert parse_name(f"path{ActionSign[Action.PROMOTE]}stage") == dict(
-        name="path", action=Action.PROMOTE, stage="stage"
+    assert parse_name(f"path{ActionSign[Action.ASSIGN]}stage") == dict(
+        name="path", action=Action.ASSIGN, stage="stage"
     )
     assert parse_name(
-        f"path{ActionSign[Action.PROMOTE]}stage{ActionSign[Action.PROMOTE]}1"
-    ) == dict(name="path", action=Action.PROMOTE, stage="stage", number=1)
+        f"path{ActionSign[Action.ASSIGN]}stage{ActionSign[Action.ASSIGN]}1"
+    ) == dict(name="path", action=Action.ASSIGN, stage="stage", number=1)
 
 
 @pytest.mark.parametrize(

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,29 +1,34 @@
+from copy import deepcopy
 from typing import Any, Dict, Sequence, Set, Union
 
 from funcy import omit
 from pydantic import BaseModel
 
 
-def _assert_equals(a, b):
+def show_difference(left: Dict, right: Dict):
+    left_ = deepcopy(left)
+    right_ = deepcopy(right)
+    for key in list(left_.keys()):
+        if left_.get(key) == right_.get(key):
+            left_.pop(key)
+            right_.pop(key)
+    return f"\n{left_} \n!=\n {right_}"
+
+
+def assert_equals(left, right):
     # separate function is helpful for debug
     # cause you see dicts without skip_keys
-    assert a == b, f"\n{a} \n!=\n {b}"
+    assert left == right, show_difference(left, right)
 
 
-def _check_obj(
-    obj: BaseModel, values: Dict[str, Any], skip_keys: Union[Set[str], Sequence[str]]
-):
-    obj_values = obj.dict(exclude=set(skip_keys))
-    _assert_equals(obj_values, values)
-    # assert obj_values == values
-
-
-def _check_dict(
-    obj: Dict[str, Any],
+def check_obj(
+    obj: Union[BaseModel, Dict[str, Any]],
     values: Dict[str, Any],
     skip_keys: Union[Set[str], Sequence[str]],
 ):
-    obj_values = omit(obj, skip_keys)
+    if isinstance(obj, BaseModel):
+        obj_values = obj.dict(exclude=set(skip_keys))
+    else:
+        obj_values = omit(obj, skip_keys)
     values = omit(values, skip_keys)
-    _assert_equals(obj_values, values)
-    # assert obj_values == values
+    assert_equals(obj_values, values)


### PR DESCRIPTION
This PR adds
1. remove a stage from the artifact version
2. mark an artifact version as deprecated
3. mark an artifact as deprecated
4. Make Stages work Like Envs

close https://github.com/iterative/gto/issues/93
close #51 

Since we're introducing multiple new actions here, we need to align names and terms in the new context. Maybe
1. `register` and `deregister` an entire artifact 
2. `publish` (`release`?) and `deprecate` a version of the artifact (can switch 1st and 2nd to avoid extra changes)
3. `assign` and `unassign` a stage to a version (or `promote` or `demote` if like the previous names).

WDYT?

A minor note for myself: we need to warn a user that he needs to deprecate a version if that version have active assignments (but we shouldn't do the same when deprecating an artifact: warn about active versions - which is a bit non-symmetrical).