### PR TITLE
Make artifacts without Git tags "annotated, but not registered"

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,8 +258,9 @@ $ gto show
 ╘═══════════════╧══════════╧════════╧═════════╧════════════╛
 ```
 
-Here we'll see both artifacts that have Git tags only and those that are
-annotated only in `artifacts.yaml` (the latter will be mark with asteriks, e.g.
+Here we'll see artifacts that have Git tags or are annotated in
+`artifacts.yaml`. The artifacts that have annotation, but have no Git tags, are
+considered yet `unregistered` and will be marked with an asterisk, e.g.
 `*annotated`. Use `--all-branches` or `--all-commits` to read `artifacts.yaml`
 from more commits than just `HEAD`.
 

--- a/README.md
+++ b/README.md
@@ -258,9 +258,10 @@ $ gto show
 ╘═══════════════╧══════════╧════════╧═════════╧════════════╛
 ```
 
-Here we'll see both artifacts that have Git tags only and those annotated in
-`artifacts.yaml`. Use `--all-branches` or `--all-commits` to read
-`artifacts.yaml` from more commits than just `HEAD`.
+Here we'll see both artifacts that have Git tags only and those that are
+annotated only in `artifacts.yaml` (the latter will be mark with asteriks, e.g.
+`*annotated`. Use `--all-branches` or `--all-commits` to read `artifacts.yaml`
+from more commits than just `HEAD`.
 
 Add an artifact name to print all of its versions instead:
 
@@ -456,14 +457,15 @@ GTO applies the config from the workspace, so if want to apply the config from
 $ GTO_EMOJIS=false gto show
 ```
 
-
 ## Contributing
 
-Contributions are welcome! Please see our [Contributing Guide](https://mlem.ai/doc/contributing/core)
-for more details.
+Contributions are welcome! Please see our
+[Contributing Guide](https://mlem.ai/doc/contributing/core) for more details.
 
-Check out the [MLEM+GTO weekly board](https://github.com/orgs/iterative/projects/322/views/4)
-to learn about what we do, and about the exciting new functionality that is going to be added soon.
+Check out the
+[MLEM+GTO weekly board](https://github.com/orgs/iterative/projects/322/views/4)
+to learn about what we do, and about the exciting new functionality that is
+going to be added soon.
 
 Thanks to all our contributors!
 
@@ -512,6 +514,8 @@ To continue experimenting, call `gto --help`
 
 ## Copyright
 
-This project is distributed under the Apache license version 2.0 (see the LICENSE file in the project root).
+This project is distributed under the Apache license version 2.0 (see the
+LICENSE file in the project root).
 
-By submitting a pull request to this project, you agree to license your contribution under the Apache license version 2.0 to this project.
+By submitting a pull request to this project, you agree to license your
+contribution under the Apache license version 2.0 to this project.

--- a/gto/api.py
+++ b/gto/api.py
@@ -342,6 +342,7 @@ def _show_registry(
                 else None
                 for name in stages
             },
+            "registered": o.is_registered,
         }
         for o in reg.get_artifacts(
             all_branches=all_branches,
@@ -352,7 +353,8 @@ def _show_registry(
         return models_state
 
     result = [
-        [name, d["version"]] + [d["stage"][name] for name in stages]
+        [name if d["registered"] else f"*{name}", d["version"]]
+        + [d["stage"][name] for name in stages]
         for name, d in models_state.items()
     ]
     headers = ["name", "latest"] + [f"#{e}" for e in stages]

--- a/gto/api.py
+++ b/gto/api.py
@@ -14,6 +14,7 @@ from gto.constants import (
     VERSION,
     VERSIONS_PER_STAGE,
     VersionSort,
+    mark_artifact_unregistered,
     shortcut_regexp,
 )
 from gto.exceptions import NoRepo, NotImplementedInGTO, WrongArgs
@@ -358,7 +359,11 @@ def _show_registry(
         OrderedDict(
             zip(
                 ["name", "latest"] + [f"#{e}" for e in stages],
-                [name, d["version"]] + [d["stage"][name] for name in stages],
+                [
+                    name if d["registered"] else mark_artifact_unregistered(name),
+                    d["version"],
+                ]
+                + [d["stage"][name] for name in stages],
             ),
         )
         for name, d in models_state.items()
@@ -428,6 +433,11 @@ def _show_versions(  # pylint: disable=too-many-locals
     first_keys = ["artifact", "version", "stage"]
     versions_ = []
     for v in versions:
+        v["artifact"] = (
+            v["artifact"]
+            if artifact.is_registered
+            else mark_artifact_unregistered(v["artifact"])
+        )
         v["version"] = format_hexsha(v["version"])
         v["stage"] = ", ".join(
             distinct(  # TODO: remove? no longer necessary

--- a/gto/base.py
+++ b/gto/base.py
@@ -425,6 +425,13 @@ class Artifact(BaseObject):
         return self.get_events(ascending=True)[0].created_at
 
     @property
+    def is_registered(self):
+        """Tells if this is an a registered artifact - i.e. there Git tags for it"""
+        return not all(
+            isinstance(e, Commit) for e in self.get_events(direct=True, indirect=True)
+        )
+
+    @property
     def unique_stages(self):
         return set(self.get_vstages())
 

--- a/gto/constants.py
+++ b/gto/constants.py
@@ -36,6 +36,10 @@ shortcut_regexp = re.compile(
 )
 
 
+def mark_artifact_unregistered(artifact_name):
+    return f"*{artifact_name}"
+
+
 class VersionSort(Enum):
     SemVer = "semver"
     Timestamp = "timestamp"


### PR DESCRIPTION
Close #226 
Now the artifact without Git tags, but with annotation, won't be considered as "registered artifact".
Those artifacts will be marked with `*` in `gto show` (and show be also marked differently in Studio):
```
$ gto show
╒════════════╤══════════╤════════╤═════════╤════════════╕
│ name       │ latest   │ #dev   │ #prod   │ #staging   │
╞════════════╪══════════╪════════╪═════════╪════════════╡
│ churn      │ v3.1.0   │ v3.1.0 │ v3.0.0  │ v3.1.0     │
│ segment    │ v0.4.1   │ v0.4.1 │ -       │ -          │
│ cv-class   │ v0.1.13  │ -      │ -       │ -          │
│ *annotated │ -        │ -      │ -       │ -          │
╘════════════╧══════════╧════════╧═════════╧════════════╛
```

We still need to come up with some term that won't be confusing: `register an artifact` and `register a version` are usually confused with each other. Maybe instead of `unregistered artifacts` (those that are annotated, but don't have Git tags yet) they should be called `artifact candidates`, or `register a version` should become `publish a version`. WDYT @tapadipti @mnrozhkov?

### TODO
- [ ] update README about this `*`