### PR TITLE
Make sort by Timestamp default, add option to choose sort

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,10 +269,14 @@ $ gto show churn
 ╒════════════╤═══════════╤══════════════╤═════════════════════╤══════════════╕
 │ artifact   │ version   │ stage        │ created_at          │ ref          │
 ╞════════════╪═══════════╪══════════════╪═════════════════════╪══════════════╡
-│ churn      │ v3.1.0    │ staging, dev │ 2022-07-14 10:33:53 │ churn@v3.1.0 │
-│ churn      │ v3.0.0    │ prod         │ 2022-07-09 19:27:13 │ churn@v3.0.0 │
+│ churn      │ v3.1.0    │ dev, staging │ 2022-08-28 16:58:50 │ churn@v3.1.0 │
+│ churn      │ v3.0.0    │ prod         │ 2022-08-24 01:52:10 │ churn@v3.0.0 │
 ╘════════════╧═══════════╧══════════════╧═════════════════════╧══════════════╛
 ```
+
+Note, that by default, assignments are sorted by the creation time (the latest
+assignment wins). You can sort them by Semver with `--sort semver` option (the
+greatest version in stage wins).
 
 #### Enabling multiple versions in the same Stage workflow
 
@@ -282,21 +286,17 @@ Note: this functionality is experimental and subject to change. If you find it
 useful, please share your feedback in GH issues to help us make it stable.
 
 If you would like to see more than a single version assigned in a stage, use
-`--av` (short for `--assignments-per-version`), e.g. `-1` to show all versions.
+`--vs` (short for `--versions-per-stage`), e.g. `-1` to show all versions.
 
 ```console
-$ gto show churn --av -1
+$ gto show churn --vs -1
 ╒════════════╤═══════════╤══════════════╤═════════════════════╤══════════════╕
 │ artifact   │ version   │ stage        │ created_at          │ ref          │
 ╞════════════╪═══════════╪══════════════╪═════════════════════╪══════════════╡
-│ churn      │ v3.1.0    │ staging, dev │ 2022-07-14 10:33:53 │ churn@v3.1.0 │
-│ churn      │ v3.0.0    │ dev, prod    │ 2022-07-09 19:27:13 │ churn@v3.0.0 │
+│ churn      │ v3.1.0    │ dev, staging │ 2022-08-28 16:58:50 │ churn@v3.1.0 │
+│ churn      │ v3.0.0    │ dev, prod    │ 2022-08-24 01:52:10 │ churn@v3.0.0 │
 ╘════════════╧═══════════╧══════════════╧═════════════════════╧══════════════╛
 ```
-
-To enable this workflow, you need to supply the `--av` argument to `gto show`
-command. Other commands behave the same way regardless of the
-approach you choose.
 
 </details>
 
@@ -308,16 +308,16 @@ Note: this functionality is experimental and subject to change. If you find it
 useful, please share your feedback in GH issues to help us make it stable.
 
 If you would like the latest stage to replace all the previous stages for an
-artifact version, use `--vs` flag (or `--versions-per-stage` for short) combined
-with `--av`:
+artifact version, use `--vs` flag combined with `--av`
+(`--assignments-per-version` for short):
 
 ```console
 $ gto show churn --av 1 --vs -1
 ╒════════════╤═══════════╤═════════╤═════════════════════╤══════════════╕
 │ artifact   │ version   │ stage   │ created_at          │ ref          │
 ╞════════════╪═══════════╪═════════╪═════════════════════╪══════════════╡
-│ churn      │ v3.1.0    │ staging │ 2022-07-14 10:33:53 │ churn@v3.1.0 │
-│ churn      │ v3.0.0    │ dev     │ 2022-07-09 19:27:13 │ churn@v3.0.0 │
+│ churn      │ v3.1.0    │ staging │ 2022-08-28 16:58:50 │ churn@v3.1.0 │
+│ churn      │ v3.0.0    │ dev     │ 2022-08-24 01:52:10 │ churn@v3.0.0 │
 ╘════════════╧═══════════╧═════════╧═════════════════════╧══════════════╛
 ```
 
@@ -325,10 +325,6 @@ In this case the version will always have a single stage (or have no stage at
 all). This resembles Kanban workflow, when you "move" your artifact version from
 one column ("stage-1") to another ("stage-2"). This is how MLFlow and some other
 Model Registries work.
-
-To enable this workflow, you need to supply the `--vs` and `--av` arguments to
-`gto show` command. Other commands behave the same way
-regardless of the approach you choose.
 
 </details>
 
@@ -342,15 +338,14 @@ $ gto history churn
 ╒═════════════════════╤════════════╤══════════════╤═══════════╤═════════╤══════════╤═════════════════╕
 │ timestamp           │ artifact   │ event        │ version   │ stage   │ commit   │ ref             │
 ╞═════════════════════╪════════════╪══════════════╪═══════════╪═════════╪══════════╪═════════════════╡
-│ 2022-07-29 14:50:10 │ churn      │ assignment   │ v3.1.0    │ dev     │ 8e4b8e9  │ churn#dev#4     │
-│ 2022-07-17 21:53:53 │ churn      │ assignment   │ v3.0.0    │ prod    │ 0d4e471  │ churn#prod#3    │
-│ 2022-07-16 18:07:13 │ churn      │ assignment   │ v3.1.0    │ staging │ 8e4b8e9  │ churn#staging#2 │
-│ 2022-07-15 14:20:33 │ churn      │ assignment   │ v3.0.0    │ dev     │ 0d4e471  │ churn#dev#1     │
-│ 2022-07-14 10:33:53 │ churn      │ registration │ v3.1.0    │ -       │ 8e4b8e9  │ churn@v3.1.0    │
-│ 2022-07-13 06:47:13 │ churn      │ commit       │ v3.1.0    │ -       │ 8e4b8e9  │ 8e4b8e9         │
-│ 2022-07-13 06:47:13 │ churn      │ commit       │ v3.1.0    │ -       │ 8e4b8e9  │ 8e4b8e9         │
-│ 2022-07-09 19:27:13 │ churn      │ registration │ v3.0.0    │ -       │ 0d4e471  │ churn@v3.0.0    │
-│ 2022-07-08 15:40:33 │ churn      │ commit       │ v3.0.0    │ -       │ 0d4e471  │ 0d4e471         │
+│ 2022-09-02 08:05:30 │ churn      │ assignment   │ v3.1.0    │ dev     │ dd5fb99  │ churn#dev#4     │
+│ 2022-09-01 04:18:50 │ churn      │ assignment   │ v3.0.0    │ prod    │ 708402b  │ churn#prod#3    │
+│ 2022-08-31 00:32:10 │ churn      │ assignment   │ v3.1.0    │ staging │ dd5fb99  │ churn#staging#2 │
+│ 2022-08-29 20:45:30 │ churn      │ assignment   │ v3.0.0    │ dev     │ 708402b  │ churn#dev#1     │
+│ 2022-08-28 16:58:50 │ churn      │ registration │ v3.1.0    │ -       │ dd5fb99  │ churn@v3.1.0    │
+│ 2022-08-27 13:12:10 │ churn      │ commit       │ v3.1.0    │ -       │ dd5fb99  │ dd5fb99         │
+│ 2022-08-24 01:52:10 │ churn      │ registration │ v3.0.0    │ -       │ 708402b  │ churn@v3.0.0    │
+│ 2022-08-22 22:05:30 │ churn      │ commit       │ v3.0.0    │ -       │ 708402b  │ 708402b         │
 ╘═════════════════════╧════════════╧══════════════╧═══════════╧═════════╧══════════╧═════════════════╛
 ```
 
@@ -399,15 +394,16 @@ $ gto check-ref awesome-model@v0.0.1
 
 ### Getting the right version
 
-To get the highest artifact version or Git reference, use `gto show artifact@greatest`:
+To get the highest artifact version or Git reference, use
+`gto show artifact@greatest`:
 
 ```console
 $ gto show churn@greatest
-╒════════════╤═══════════╤═════════╤═════════════════════╤══════════════╕
-│ artifact   │ version   │ stage   │ created_at          │ ref          │
-╞════════════╪═══════════╪═════════╪═════════════════════╪══════════════╡
-│ churn      │ v3.1.0    │ staging │ 2022-08-24 08:02:53 │ churn@v3.1.0 │
-╘════════════╧═══════════╧═════════╧═════════════════════╧══════════════╛
+╒════════════╤═══════════╤══════════════╤═════════════════════╤══════════════╕
+│ artifact   │ version   │ stage        │ created_at          │ ref          │
+╞════════════╪═══════════╪══════════════╪═════════════════════╪══════════════╡
+│ churn      │ v3.1.0    │ dev, staging │ 2022-08-28 16:58:50 │ churn@v3.1.0 │
+╘════════════╧═══════════╧══════════════╧═════════════════════╧══════════════╛
 
 $ gto show churn@greatest --ref
 churn@v3.1.0
@@ -421,7 +417,7 @@ $ gto show churn#prod
 ╒════════════╤═══════════╤═════════╤═════════════════════╤══════════════╕
 │ artifact   │ version   │ stage   │ created_at          │ ref          │
 ╞════════════╪═══════════╪═════════╪═════════════════════╪══════════════╡
-│ churn      │ v3.0.0    │ prod    │ 2022-08-19 16:56:13 │ churn@v3.0.0 │
+│ churn      │ v3.0.0    │ prod    │ 2022-08-24 01:52:10 │ churn@v3.0.0 │
 ╘════════════╧═══════════╧═════════╧═════════════════════╧══════════════╛
 
 $ gto show churn#prod --ref

--- a/README.md
+++ b/README.md
@@ -152,13 +152,13 @@ consumer, and maybe signal a downstream system about this. You can use
 
 ```console
 $ gto deprecate awesome-model v0.0.1 prod
-Created git tag 'awesome-model#prod#2!' that unassigns a stage from 'v0.0.1'
+Created git tag 'awesome-model#prod!#2' that unassigns a stage from 'v0.0.1'
 ```
 
 <details summary="Some details and options">
 
 GTO creates a special Git tag in a standard format:
-`{artifact_name}#{stage}#{e}!`.
+`{artifact_name}#{stage}!#{e}`.
 
 Note, that later you can create this stage again, if you need to, by calling
 `$ gto assign` again.
@@ -197,9 +197,9 @@ use
 $ gto deprecate awesome-model v0.0.1 --delete
 Deleted git tag 'awesome-model@v0.0.1' that registered a version.
 Deleted git tag 'awesome-model#prod#1' that assigned a stage to 'v0.0.1'.
-Deleted git tag 'awesome-model#prod#2!' that unassigned a stage to 'v0.0.1'.
+Deleted git tag 'awesome-model#prod!#2' that unassigned a stage to 'v0.0.1'.
 To push the changes upstream, run:
-git push origin awesome-model@v0.0.1 awesome-model#prod#1 awesome-model#prod#2! --delete
+git push origin awesome-model@v0.0.1 awesome-model#prod#1 awesome-model#prod!#2 --delete
 ```
 
 This includes all Git tags related to the version: a tag that registered it and
@@ -230,9 +230,9 @@ all of them for the artifact. You could do that with
 $ gto deprecate awesome-model --delete
 Deleted git tag 'awesome-model@v0.0.1' that registered a version.
 Deleted git tag 'awesome-model#prod#1' that assigned a stage to 'v0.0.1'.
-Deleted git tag 'awesome-model#prod#2!' that unassigned a stage to 'v0.0.1'.
+Deleted git tag 'awesome-model#prod!#2' that unassigned a stage to 'v0.0.1'.
 To push the changes upstream, run:
-git push origin awesome-model@v0.0.1 awesome-model#prod#1 awesome-model#prod#2! --delete
+git push origin awesome-model@v0.0.1 awesome-model#prod#1 awesome-model#prod!#2 --delete
 ```
 
 </details>
@@ -244,7 +244,7 @@ Let's look at the usage of the `gto show` and `gto history`.
 ### Show the current state
 
 This is the entire state of the registry: all artifacts, their latest versions,
-and the greatest versions for each stage.
+and the versions in each stage.
 
 ```console
 $ gto show
@@ -295,7 +295,7 @@ $ gto show churn --av -1
 ```
 
 To enable this workflow, you need to supply the `--av` argument to `gto show`
-and `gto which` commands. Other commands behave the same way regardless of the
+command. Other commands behave the same way regardless of the
 approach you choose.
 
 </details>
@@ -327,7 +327,7 @@ one column ("stage-1") to another ("stage-2"). This is how MLFlow and some other
 Model Registries work.
 
 To enable this workflow, you need to supply the `--vs` and `--av` arguments to
-`gto show` and `gto which` commands. Other commands behave the same way
+`gto show` command. Other commands behave the same way
 regardless of the approach you choose.
 
 </details>
@@ -357,7 +357,7 @@ $ gto history churn
 ## Consuming the registry downstream
 
 Let's look at integrating with GTO via Git as well as using the `gto check-ref`,
-`gto latest`, `gto which`, and `gto describe` utility commands downstream.
+`gto show`, and `gto describe` utility commands downstream.
 
 ### Act on new versions and stage assignments in CI
 
@@ -399,26 +399,33 @@ $ gto check-ref awesome-model@v0.0.1
 
 ### Getting the right version
 
-To get the latest artifact version, its path, and Git reference, use
-`gto latest`:
+To get the highest artifact version or Git reference, use `gto show artifact@greatest`:
 
 ```console
-$ gto latest churn
-v3.1.0
+$ gto show churn@greatest
+╒════════════╤═══════════╤═════════╤═════════════════════╤══════════════╕
+│ artifact   │ version   │ stage   │ created_at          │ ref          │
+╞════════════╪═══════════╪═════════╪═════════════════════╪══════════════╡
+│ churn      │ v3.1.0    │ staging │ 2022-08-24 08:02:53 │ churn@v3.1.0 │
+╘════════════╧═══════════╧═════════╧═════════════════════╧══════════════╛
 
-$ gto latest churn --ref
+$ gto show churn@greatest --ref
 churn@v3.1.0
 ```
 
-To get the version that is currently assigned to an environment (stage), use
-`gto which`:
+To get the version that is currently assigned to a stage, use
+`gto show artifact#stage`:
 
 ```console
-$ gto which churn dev
-v3.1.0
+$ gto show churn#prod
+╒════════════╤═══════════╤═════════╤═════════════════════╤══════════════╕
+│ artifact   │ version   │ stage   │ created_at          │ ref          │
+╞════════════╪═══════════╪═════════╪═════════════════════╪══════════════╡
+│ churn      │ v3.0.0    │ prod    │ 2022-08-19 16:56:13 │ churn@v3.0.0 │
+╘════════════╧═══════════╧═════════╧═════════════════════╧══════════════╛
 
-$ gto which churn dev --ref
-churn#dev#4
+$ gto show churn#prod --ref
+churn@v3.0.0
 ```
 
 To get details about an artifact (from `artifacts.yaml`) use `gto describe`:

--- a/gto/api.py
+++ b/gto/api.py
@@ -12,6 +12,7 @@ from gto.constants import (
     STAGE,
     VERSION,
     VERSIONS_PER_STAGE,
+    VersionSort,
 )
 from gto.exceptions import NoRepo, NotImplementedInGTO, WrongArgs
 from gto.ext import EnrichmentInfo
@@ -271,7 +272,8 @@ def show(
     truncate_hexsha=False,
     registered_only=False,
     assignments_per_version=ASSIGNMENTS_PER_VERSION,
-    versions_per_stage=1,
+    versions_per_stage=VERSIONS_PER_STAGE,
+    sort=VersionSort.Timestamp,
     table: bool = False,
 ):
     return (
@@ -283,6 +285,7 @@ def show(
             registered_only=registered_only,
             assignments_per_version=assignments_per_version,
             versions_per_stage=versions_per_stage,
+            sort=sort,
             table=table,
             truncate_hexsha=truncate_hexsha,
         )
@@ -294,6 +297,7 @@ def show(
             registered_only=registered_only,
             assignments_per_version=assignments_per_version,
             versions_per_stage=versions_per_stage,
+            sort=sort,
             table=table,
             truncate_hexsha=truncate_hexsha,
         )
@@ -305,8 +309,9 @@ def _show_registry(
     all_branches=False,
     all_commits=False,
     registered_only=False,
-    assignments_per_version: int = ASSIGNMENTS_PER_VERSION,
-    versions_per_stage: int = VERSIONS_PER_STAGE,
+    assignments_per_version: int = None,
+    versions_per_stage: int = None,
+    sort: VersionSort = None,
     table: bool = False,
     truncate_hexsha: bool = False,
 ):
@@ -330,16 +335,11 @@ def _show_registry(
                             registered_only=registered_only,
                             assignments_per_version=assignments_per_version,
                             versions_per_stage=versions_per_stage,
-                        )[name]
+                            sort=sort,
+                        ).get(name, [])
                     ]
                 )
-                if name
-                in o.get_vstages(
-                    registered_only=registered_only,
-                    assignments_per_version=assignments_per_version,
-                    versions_per_stage=versions_per_stage,
-                )
-                else None
+                or None
                 for name in stages
             },
         }
@@ -368,6 +368,7 @@ def _show_versions(  # pylint: disable=too-many-locals
     registered_only=False,
     assignments_per_version: int = None,
     versions_per_stage: int = None,
+    sort: VersionSort = None,
     table: bool = False,
     truncate_hexsha: bool = False,
 ):
@@ -389,6 +390,7 @@ def _show_versions(  # pylint: disable=too-many-locals
         registered_only=registered_only,
         assignments_per_version=assignments_per_version,
         versions_per_stage=versions_per_stage,
+        sort=sort,
     )
     versions = []
     for v in artifact.get_versions(

--- a/gto/api.py
+++ b/gto/api.py
@@ -353,12 +353,15 @@ def _show_registry(
     if not table:
         return models_state
 
-    result = [
-        [name, d["version"]] + [d["stage"][name] for name in stages]
+    return [
+        OrderedDict(
+            zip(
+                ["name", "latest"] + [f"#{e}" for e in stages],
+                [name, d["version"]] + [d["stage"][name] for name in stages],
+            ),
+        )
         for name, d in models_state.items()
-    ]
-    headers = ["name", "latest"] + [f"#{e}" for e in stages]
-    return result, headers
+    ], "keys"
 
 
 def _show_versions(  # pylint: disable=too-many-locals

--- a/gto/cli.py
+++ b/gto/cli.py
@@ -802,6 +802,10 @@ def show(
         Show versions of specific artifact in registry:
         $ gto show nn
 
+        Show greatest version or what's in stage:
+        $ gto show nn@greatest
+        $ gto show nn#prod
+
         Use --all-branches and --all-commits to read more than just HEAD:
         $ gto show --all-branches
         $ gto show nn --all-commits

--- a/gto/constants.py
+++ b/gto/constants.py
@@ -31,6 +31,9 @@ name_regexp = re.compile(f"^{name}$")
 tag_regexp = re.compile(
     f"^(?P<artifact>{name})(((#(?P<stage>{name})|@(?P<version>v{semver}))(?P<cancel>!?))|@((?P<deprecated>deprecated)|(?P<created>created)))(#({counter}))?$"
 )
+shortcut_regexp = re.compile(
+    f"^(?P<artifact>{name})(((#(?P<stage>{name})|@(?P<latest>latest)|@(?P<greatest>greatest))))$"
+)
 
 
 class VersionSort(Enum):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -102,34 +102,34 @@ EXPECTED_DESCRIBE_OUTPUT = """{
 def test_commands(showcase):
     path, repo, write_file, first_commit, second_commit = showcase
     _check_successful_cmd(
-        "latest",
-        ["-r", path, "rf"],
+        "show",
+        ["-r", path, "rf@greatest", "--version"],
         "v1.2.4\n",
     )
     _check_successful_cmd(
-        "latest",
-        ["-r", path, "rf", "--ref"],
+        "show",
+        ["-r", path, "rf@greatest", "--ref"],
         "rf@v1.2.4\n",
     )
     _check_successful_cmd(
-        "which",
-        ["-r", path, "rf", "production"],
-        "v1.2.4\n",
+        "show",
+        ["-r", path, "rf#production", "--version"],
+        "v1.2.3\n",
     )
     _check_successful_cmd(
-        "which",
-        ["-r", path, "rf", "production", "--vs", "-1"],
+        "show",
+        ["-r", path, "rf#production", "--vs", "-1", "--version"],
         "v1.2.4\nv1.2.3\n",
     )
     _check_successful_cmd(
-        "which",
-        ["-r", path, "rf", "staging", "--vs", "-1"],
+        "show",
+        ["-r", path, "rf#staging", "--vs", "-1", "--version"],
         "v1.2.4\n",
     )
     _check_successful_cmd(
-        "which",
-        ["-r", path, "rf", "production", "--ref"],
-        "rf#production#3\n",
+        "show",
+        ["-r", path, "rf#production", "--ref"],
+        "rf@v1.2.3\n",
     )
     _check_successful_cmd("describe", ["-r", path, "rf"], EXPECTED_DESCRIBE_OUTPUT)
     _check_successful_cmd(


### PR DESCRIPTION
close #132 

## Done

Added `--sort` option to `show` (Order assignments by timestamp or semver [default: timestamp])

```shell
$ gto show --sort timestamp
$ gto show --sort semver
```

```shell
$ gto show bug
╒════════════╤═══════════╤═════════╤═════════════════════╤════════════╕
│ artifact   │ version   │ stage   │ created_at          │ ref        │
╞════════════╪═══════════╪═════════╪═════════════════════╪════════════╡
│ bug        │ v0.0.3    │ dev     │ 2022-07-25 18:03:34 │ bug@v0.0.3 │
│ bug        │ v0.0.2    │ prod    │ 2022-07-04 15:27:12 │ bug@v0.0.2 │
│ bug        │ v0.0.1    │         │ 2022-07-04 15:27:05 │ bug@v0.0.1 │
╘════════════╧═══════════╧═════════╧═════════════════════╧════════════╛
$ gto show bug@greatest
╒════════════╤═══════════╤═════════╤═════════════════════╤════════════╕
│ artifact   │ version   │ stage   │ created_at          │ ref        │
╞════════════╪═══════════╪═════════╪═════════════════════╪════════════╡
│ bug        │ v0.0.3    │ dev     │ 2022-07-25 18:03:34 │ bug@v0.0.3 │
╘════════════╧═══════════╧═════════╧═════════════════════╧════════════╛
$ gto show bug#prod
╒════════════╤═══════════╤═════════╤═════════════════════╤════════════╕
│ artifact   │ version   │ stage   │ created_at          │ ref        │
╞════════════╪═══════════╪═════════╪═════════════════════╪════════════╡
│ bug        │ v0.0.2    │ prod    │ 2022-07-04 15:27:12 │ bug@v0.0.2 │
╘════════════╧═══════════╧═════════╧═════════════════════╧════════════╛
$ gto show bug#prod --name
v0.0.2
```

### Side note

- `$ gto show model#dev` is equivalent of `$ gto latest model dev`,
- the same is true for `$ gto show model#dev --sort semver` and `$ gto greatest model dev`.

To keep CLI experience more simple and consize I deprecated `$ gto latest` and `$ gto which` and didn't introduce `$ gto greatest`.
