### PR TITLE
Rename `gto.api.unregister` to `gto.api.deregister`

### DIFF
--- a/gto/api.py
+++ b/gto/api.py
@@ -178,7 +178,7 @@ def unassign(
     )
 
 
-def unregister(
+def deregister(
     repo: Union[str, Repo],
     name: str,
     ref: str = None,
@@ -191,7 +191,7 @@ def unregister(
     author: Optional[str] = None,
     author_email: Optional[str] = None,
 ):
-    return GitRegistry.from_repo(repo).unregister(
+    return GitRegistry.from_repo(repo).deregister(
         name=name,
         ref=ref,
         version=version,

--- a/gto/cli.py
+++ b/gto/cli.py
@@ -630,7 +630,7 @@ def deprecate(
             stdout=True,
         )
     elif version:
-        gto.api.unregister(
+        gto.api.deregister(
             repo=repo,
             name=name,
             version=version,

--- a/gto/registry.py
+++ b/gto/registry.py
@@ -196,7 +196,7 @@ class GitRegistry(BaseModel):
             self._echo_git_suggestion(tag)
         return self._return_event(tag)
 
-    def unregister(  # pylint: disable=too-many-locals
+    def deregister(  # pylint: disable=too-many-locals
         self,
         name,
         ref=None,

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -118,7 +118,7 @@ def test_register_deregister(repo_with_artifact):
     assert latest.author == author
     assert latest.author_email == author_email
 
-    gto.api.unregister(repo=repo.working_dir, name=name, version=vname2)
+    gto.api.deregister(repo=repo.working_dir, name=name, version=vname2)
     latest = gto.api.find_latest_version(repo.working_dir, name)
     assert latest.version == vname1
 


### PR DESCRIPTION
Found out that the event is called `Deregistration`, but the API method was `unregister`. Since we're calling `unregistered artifact` the one that wasn't registered yet, better to use `deregistered` to describe the one which registration was deprecated. cc @amritghimire - this will be a breaking change in new GTO release.