### PR TITLE
Fix/stderr

### DIFF
--- a/gto/cli.py
+++ b/gto/cli.py
@@ -18,7 +18,16 @@ from gto.constants import (
     VersionSort,
 )
 from gto.exceptions import GTOException, NotImplementedInGTO, WrongArgs
-from gto.ui import EMOJI_FAIL, EMOJI_GTO, EMOJI_OK, bold, cli_echo, color, echo
+from gto.ui import (
+    EMOJI_FAIL,
+    EMOJI_GTO,
+    EMOJI_OK,
+    bold,
+    cli_echo,
+    color,
+    echo,
+    stderr_echo,
+)
 from gto.utils import format_echo, make_ready_to_serialize
 
 
@@ -414,14 +423,14 @@ def gto_command(*args, section="other", aliases=None, parent=app, **kwargs):
                 error = str(type(e))
                 if ctx.obj["traceback"]:
                     raise
-                with cli_echo():
+                with stderr_echo():
                     echo(EMOJI_FAIL + color(str(e), col=typer.colors.RED))
                 raise typer.Exit(1) from e
             except Exception as e:  # pylint: disable=broad-except
                 error = str(type(e))
                 if ctx.obj["traceback"]:
                     raise
-                with cli_echo():
+                with stderr_echo():
                     echo(
                         (
                             EMOJI_FAIL
@@ -429,7 +438,7 @@ def gto_command(*args, section="other", aliases=None, parent=app, **kwargs):
                         )
                     )
                     echo(
-                        "Please report it here running with '--traceback' flag: <https://github.com/iterative/gto/issues>"
+                        "Please report it here running with '--traceback' flag: <https://github.com/iterative/gto/issues>\n"
                     )
                 raise typer.Exit(1) from e
             finally:

--- a/gto/cli.py
+++ b/gto/cli.py
@@ -438,7 +438,7 @@ def gto_command(*args, section="other", aliases=None, parent=app, **kwargs):
                         )
                     )
                     echo(
-                        "Please report it here running with '--traceback' flag: <https://github.com/iterative/gto/issues>\n"
+                        "Please report it here running with '--traceback' flag: <https://github.com/iterative/gto/issues>"
                     )
                 raise typer.Exit(1) from e
             finally:

--- a/gto/ui.py
+++ b/gto/ui.py
@@ -10,6 +10,7 @@ from rich.text import Text
 from gto.config import CONFIG
 
 console = Console()
+error_console = Console(stderr=True)
 
 _echo_func: Optional[Callable] = None
 
@@ -31,6 +32,12 @@ def set_echo(echo_func=...):
 @contextlib.contextmanager
 def cli_echo():
     with set_echo(console.print):
+        yield
+
+
+@contextlib.contextmanager
+def stderr_echo():
+    with set_echo(error_console.print):
         yield
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,9 +4,25 @@ from typing import Callable, Tuple
 
 import git
 import pytest
+from click.testing import Result
+from typer.testing import CliRunner
 
 import gto
+from gto.cli import app
 from gto.config import CONFIG_FILE_NAME
+
+
+class Runner:
+    def __init__(self):
+        self._runner = CliRunner(mix_stderr=False)
+
+    def invoke(self, *args, **kwargs) -> Result:
+        return self._runner.invoke(app, *args, **kwargs)
+
+
+@pytest.fixture
+def runner() -> Runner:
+    return Runner()
 
 
 @pytest.fixture


### PR DESCRIPTION
Hi @aguschin, 

I've completed the pull request for https://github.com/iterative/gto/issues/265. 

I've implemented a similar fix for MLEM and further details can be found here: https://github.com/iterative/mlem/pull/410

I've completed the following updates: 
1. Implemented a context manager `stderr_echo` to print to `stderr`.
2. Implemented the printing of `Exception` and `GTOException` to `stderr` as opposed to `stdout` using the `stderr_echo` context manager.
3.  Updated `conftest.py` with a `Runner` class similar to the MLEM project. So that `CliRunner` instances will be created with standard parameters such as `mixed_stderr=False`. With this implementation, we will guarantee that the `result` object will have `stderr` and `stdout` properties. 
4. Implemented a `Runner` pytest fixture, similar to the MLEM project, however, no tests are using it currently. I've added it for future use cases. 
5. Implemented 2 tests that ensure `Exception` and `GTOException` are printed to `stderr`. 
6. Implemented 2 helper functions `_check_output_contains(output: str, search_value: str) -> bool:` and `_check_output_exact_match(output: str, search_value: str) -> bool`. 
7. The functions in item 6 are used to determine how `_check_successful_cmd` and `_check_failing_cmd` should compare `stderr` and `stdout` with their expected output. 
8. The functions in item 6 are needed because in the current implementation, streams are exacted matched with their expected outputs, however, when printing to `stderr` the `gto` application adds the colour red to the output, which prevents exact match. `_check_output_contains` allows us to match a substring, correcting the issue.