### PR TITLE
Add `--branch` option to `annotate` and `remove`

### DIFF
--- a/gto/api.py
+++ b/gto/api.py
@@ -59,6 +59,7 @@ def annotate(
     commit: bool = False,
     push: bool = False,
     branch: str = None,
+    stdout: bool = False,
     # update: bool = False,
 ):
     """Add an artifact to the Index"""
@@ -73,6 +74,7 @@ def annotate(
             update=True,
             commit=commit,
             push=push or is_url_of_remote_repo(repo),
+            stdout=stdout,
         )
 
 
@@ -82,6 +84,7 @@ def remove(
     commit: bool = False,
     push: bool = False,
     branch: str = None,
+    stdout: bool = False,
 ):
     """Remove an artifact from the Index"""
     with RepoIndexManager.from_repo(repo, branch=branch) as index:
@@ -89,6 +92,7 @@ def remove(
             name,
             commit=commit,
             push=push or is_url_of_remote_repo(repo),
+            stdout=stdout,
         )
 
 

--- a/gto/api.py
+++ b/gto/api.py
@@ -58,10 +58,11 @@ def annotate(
     description: str = "",
     commit: bool = False,
     push: bool = False,
+    branch: str = None,
     # update: bool = False,
 ):
     """Add an artifact to the Index"""
-    with RepoIndexManager.from_repo(repo) as index:
+    with RepoIndexManager.from_repo(repo, branch=branch) as index:
         return index.add(
             name,
             type=type,
@@ -80,9 +81,10 @@ def remove(
     name: str,
     commit: bool = False,
     push: bool = False,
+    branch: str = None,
 ):
     """Remove an artifact from the Index"""
-    with RepoIndexManager.from_repo(repo) as index:
+    with RepoIndexManager.from_repo(repo, branch=branch) as index:
         return index.remove(
             name,
             commit=commit,

--- a/gto/cli.py
+++ b/gto/cli.py
@@ -514,6 +514,7 @@ def annotate(
         commit=commit,
         push=push,
         branch=branch,
+        stdout=True,
         # update=update,
     )
 
@@ -527,7 +528,9 @@ def remove(
     branch: str = option_branch,
 ):
     """Remove the enrichment for given artifact."""
-    gto.api.remove(repo=repo, name=name, commit=commit, push=push, branch=branch)
+    gto.api.remove(
+        repo=repo, name=name, commit=commit, push=push, branch=branch, stdout=True
+    )
 
 
 @gto_command(section=CommandGroups.modifying)

--- a/gto/cli.py
+++ b/gto/cli.py
@@ -373,19 +373,20 @@ option_push_tag = Option(
     is_flag=True,
     help="Push created tag automatically (experimental)",
 )
-
 option_commit = Option(
     False,
     "--commit",
     is_flag=True,
     help="Automatically commit changes due to this command (experimental)",
 )
-
 option_push_commit = Option(
     False,
     "--push",
     is_flag=True,
     help="Push created commit automatically (experimental) - will set commit=True",
+)
+option_branch = Option(
+    None, "-b", "--branch", help="Branch to commit to. Only for remote repos."
 )
 
 
@@ -496,6 +497,7 @@ def annotate(
     description: str = Option("", "-d", "--description", help="Artifact description"),
     commit: bool = option_commit,
     push: bool = option_push_commit,
+    branch: str = option_branch,
     # update: bool = Option(
     #     False, "-u", "--update", is_flag=True, help="Update artifact if it exists"
     # ),
@@ -511,6 +513,7 @@ def annotate(
         description=description,
         commit=commit,
         push=push,
+        branch=branch,
         # update=update,
     )
 
@@ -521,9 +524,10 @@ def remove(
     name: str = arg_name,
     commit: bool = option_commit,
     push: bool = option_push_commit,
+    branch: str = option_branch,
 ):
     """Remove the enrichment for given artifact."""
-    gto.api.remove(repo, name, commit, push)
+    gto.api.remove(repo=repo, name=name, commit=commit, push=push, branch=branch)
 
 
 @gto_command(section=CommandGroups.modifying)

--- a/gto/commit_message_generator.py
+++ b/gto/commit_message_generator.py
@@ -12,7 +12,7 @@ def generate_annotate_commit_message(
 
 
 def generate_remove_commit_message(name: str) -> str:
-    return f"Remove annotation for artifact {name}"
+    return f"Remove annotation for artifact `{name}`"
 
 
 def generate_empty_commit_message() -> str:

--- a/gto/index.py
+++ b/gto/index.py
@@ -29,12 +29,11 @@ from gto.exceptions import (
     ArtifactExists,
     ArtifactNotFound,
     NoFile,
-    NoRepo,
     PathIsUsed,
     WrongArgs,
 )
 from gto.ext import EnrichmentInfo, EnrichmentReader
-from gto.git_utils import RemoteRepoMixin
+from gto.git_utils import RemoteRepoMixin, read_repo
 from gto.utils import resolve_ref
 
 
@@ -265,11 +264,7 @@ class RepoIndexManager(FileIndexManager, RemoteRepoMixin):
 
     @classmethod
     def from_local_repo(cls, repo: Union[str, git.Repo], config: RegistryConfig = None):
-        if isinstance(repo, str):
-            try:
-                repo = git.Repo(repo, search_parent_directories=True)
-            except git.InvalidGitRepositoryError as e:
-                raise NoRepo("No git repo found") from e
+        repo = read_repo(repo, search_parent_directories=True)
         if config is None:
             config = read_registry_config(
                 os.path.join(repo.working_dir, CONFIG_FILE_NAME)

--- a/gto/index.py
+++ b/gto/index.py
@@ -34,6 +34,7 @@ from gto.exceptions import (
 )
 from gto.ext import EnrichmentInfo, EnrichmentReader
 from gto.git_utils import RemoteRepoMixin, read_repo
+from gto.ui import echo
 from gto.utils import resolve_ref
 
 
@@ -188,7 +189,9 @@ class BaseIndexManager(BaseModel, ABC):
     def get_history(self) -> Dict[str, Index]:
         raise NotImplementedError
 
-    def add(self, name, type, path, must_exist, labels, description, update):
+    def add(
+        self, name, type, path, must_exist, labels, description, update, stdout=False
+    ):
         for arg in [name] + list(labels or []):
             assert_name_is_valid(arg)
         if type:
@@ -211,11 +214,15 @@ class BaseIndexManager(BaseModel, ABC):
             update=update,
         )
         self.update()
+        if stdout:
+            echo("Updated `artifacts.yaml`")
 
-    def remove(self, name):
+    def remove(self, name, stdout=False):
         index = self.get_index()
         index.remove(name)
         self.update()
+        if stdout:
+            echo("Updated `artifacts.yaml`")
 
 
 class FileIndexManager(BaseIndexManager):
@@ -280,6 +287,7 @@ class RepoIndexManager(FileIndexManager, RemoteRepoMixin):
         labels,
         description,
         update,
+        stdout=False,
         commit=False,
         commit_message=None,
         push=False,
@@ -290,6 +298,7 @@ class RepoIndexManager(FileIndexManager, RemoteRepoMixin):
             commit_message=commit_message
             or generate_annotate_commit_message(name=name, type=type, path=path),
             push=push,
+            stdout=stdout,
             name=name,
             type=type,
             path=path,
@@ -302,6 +311,7 @@ class RepoIndexManager(FileIndexManager, RemoteRepoMixin):
     def remove(
         self,
         name,
+        stdout=False,
         commit=False,
         commit_message=None,
         push=False,
@@ -311,6 +321,7 @@ class RepoIndexManager(FileIndexManager, RemoteRepoMixin):
             commit=commit,
             commit_message=commit_message or generate_remove_commit_message(name=name),
             push=push,
+            stdout=stdout,
             name=name,
         )
 

--- a/gto/registry.py
+++ b/gto/registry.py
@@ -5,7 +5,6 @@ from typing import Optional, TypeVar, Union
 
 import git
 from funcy import distinct
-from git import InvalidGitRepositoryError, NoSuchPathError, Repo
 from pydantic import BaseModel
 
 from gto.base import (
@@ -25,13 +24,12 @@ from gto.config import (
 )
 from gto.constants import NAME
 from gto.exceptions import (
-    NoRepo,
     NotImplementedInGTO,
     VersionAlreadyRegistered,
     VersionExistsForCommit,
     WrongArgs,
 )
-from gto.git_utils import RemoteRepoMixin, git_push_tag
+from gto.git_utils import RemoteRepoMixin, git_push_tag, read_repo
 from gto.index import EnrichmentManager
 from gto.tag import (
     TagArtifactManager,
@@ -58,12 +56,8 @@ class GitRegistry(BaseModel, RemoteRepoMixin):
         arbitrary_types_allowed = True
 
     @classmethod
-    def from_local_repo(cls, repo: Union[str, Repo], config: RegistryConfig = None):
-        if isinstance(repo, str):
-            try:
-                repo = git.Repo(repo, search_parent_directories=True)
-            except (InvalidGitRepositoryError, NoSuchPathError) as e:
-                raise NoRepo(repo) from e
+    def from_local_repo(cls, repo: Union[str, git.Repo], config: RegistryConfig = None):
+        repo = read_repo(repo, search_parent_directories=True)
         if config is None:
             config = read_registry_config(
                 os.path.join(repo.working_dir, CONFIG_FILE_NAME)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -246,7 +246,8 @@ def test_annotate(empty_git_repo: Tuple[git.Repo, Callable]):
             "--description",
             "some description",
         ],
-        "",
+        "Updated `artifacts.yaml`",
+        _check_output_contains,
     )
     _check_successful_cmd(
         "annotate",
@@ -259,7 +260,8 @@ def test_annotate(empty_git_repo: Tuple[git.Repo, Callable]):
             "--description",
             "new description",
         ],
-        "",
+        "Updated `artifacts.yaml`",
+        _check_output_contains,
     )
     with RepoIndexManager.from_repo(repo.working_dir) as index:
         artifact = index.get_index().state[name]  # pylint: disable=protected-access
@@ -280,7 +282,12 @@ def test_annotate(empty_git_repo: Tuple[git.Repo, Callable]):
     _check_successful_cmd(
         "describe", ["-r", repo.working_dir, name], EXPECTED_DESCRIBE_OUTPUT_2
     )
-    _check_successful_cmd("remove", ["-r", repo.working_dir, name], "")
+    _check_successful_cmd(
+        "remove",
+        ["-r", repo.working_dir, name],
+        "Updated `artifacts.yaml`",
+        _check_output_contains,
+    )
     write_file(name, "new-artifact update")
     repo.index.add(["artifacts.yaml"])
     repo.index.commit("Remove new artifact")

--- a/tests/test_git_utils.py
+++ b/tests/test_git_utils.py
@@ -70,7 +70,7 @@ def test_git_push_tag_if_called_then_gitpython_corresponding_methods_are_correct
 
     git_push_tag(repo=path, tag_name=tag_name, remote_name=remote_name)
 
-    MockedRepo.assert_called_once_with(path=path)
+    MockedRepo.assert_called_once_with(path, search_parent_directories=False)
     mocked_repo.remote.assert_called_once_with(name=remote_name)
     mocked_remote.push.assert_called_once_with([tag_name])
 
@@ -89,7 +89,7 @@ def test_git_push_tag_if_called_with_delete_then_gitpython_corresponding_methods
 
     git_push_tag(repo=path, tag_name=tag_name, delete=True, remote_name=remote_name)
 
-    MockedRepo.assert_called_once_with(path=path)
+    MockedRepo.assert_called_once_with(path, search_parent_directories=False)
     mocked_repo.remote.assert_called_once_with(name=remote_name)
     mocked_remote.push.assert_called_once_with(["--delete", tag_name])
 
@@ -286,7 +286,9 @@ def test_git_push_if_called_then_corresponding_gitpython_functions_are_called(
     with patch("gto.git_utils.git.Repo") as MockedRepo:
         git_push(repo=tmp_local_empty_git_repo)
 
-    MockedRepo.assert_called_once_with(path=tmp_local_empty_git_repo)
+    MockedRepo.assert_called_once_with(
+        tmp_local_empty_git_repo, search_parent_directories=False
+    )
     MockedRepo.return_value.git.push.assert_called_once_with()
 
 


### PR DESCRIPTION
fix #305 

- [x] implement
- [x] print explanation messages after running `annotate` and `remove`
- [ ] use `commit messages` as what is printed to a user and vice versa
- [x] add tests