### PR TITLE
Add `gto doctor`

### DIFF
--- a/gto/api.py
+++ b/gto/api.py
@@ -96,6 +96,22 @@ def remove(
         )
 
 
+def describe(
+    repo: Union[str, Repo], name: str, rev: str = None
+) -> List[EnrichmentInfo]:
+    """Find enrichments for the artifact"""
+    ref_type, parsed = parse_name_reference(name)
+    if ref_type == NAME_REFERENCE.NAME:
+        with EnrichmentManager.from_repo(repo) as em:
+            return em.describe(name=name, rev=rev)
+    if ref_type == NAME_REFERENCE.TAG:
+        if rev:
+            raise WrongArgs("Should not specify revision if you pass git tag")
+        with EnrichmentManager.from_repo(repo) as em:
+            return em.describe(name=parsed[NAME], rev=name)
+    raise NotImplementedError
+
+
 def register(
     repo: Union[str, Repo],
     name: str,
@@ -489,22 +505,6 @@ def _show_versions(  # pylint: disable=too-many-locals
         )
         versions_.append(v)
     return versions_, "keys"
-
-
-def describe(
-    repo: Union[str, Repo], name: str, rev: str = None
-) -> List[EnrichmentInfo]:
-    """Find enrichments for the artifact"""
-    ref_type, parsed = parse_name_reference(name)
-    if ref_type == NAME_REFERENCE.NAME:
-        with EnrichmentManager.from_repo(repo) as em:
-            return em.describe(name=name, rev=rev)
-    if ref_type == NAME_REFERENCE.TAG:
-        if rev:
-            raise WrongArgs("Should not specify revision if you pass git tag")
-        with EnrichmentManager.from_repo(repo) as em:
-            return em.describe(name=parsed[NAME], rev=name)
-    raise NotImplementedError
 
 
 def history(

--- a/gto/cli.py
+++ b/gto/cli.py
@@ -533,6 +533,39 @@ def remove(
     )
 
 
+@gto_command(section=CommandGroups.enriching)
+def describe(
+    repo: str = option_repo,
+    name: str = arg_name,
+    rev: str = option_rev,
+    type: Optional[bool] = option_show_type,
+    path: Optional[bool] = option_show_path,
+    description: Optional[bool] = option_show_description,
+):
+    """Display enrichments for an artifact."""
+    assert (
+        sum(bool(i) for i in (type, path, description)) <= 1
+    ), "Can output one key only"
+    infos = gto.api.describe(repo=repo, name=name, rev=rev)
+    if not infos:
+        return
+    d = infos[0].get_object().dict(exclude_defaults=True)
+    if type:
+        if "type" not in d:
+            raise WrongArgs("No type in enrichment")
+        echo(d["type"])
+    elif path:
+        if "path" not in d:
+            raise WrongArgs("No path in enrichment")
+        echo(d["path"])
+    elif description:
+        if "description" not in d:
+            raise WrongArgs("No description in enrichment")
+        echo(d["description"])
+    else:
+        format_echo(d, "json")
+
+
 @gto_command(section=CommandGroups.modifying)
 def register(
     repo: str = option_repo,
@@ -875,37 +908,12 @@ def print_index(repo: str = option_repo):
         format_echo(index.artifact_centric_representation(), "json")
 
 
-@gto_command(section=CommandGroups.enriching)
-def describe(
+@gto_command()
+def doctor(
     repo: str = option_repo,
-    name: str = arg_name,
-    rev: str = option_rev,
-    type: Optional[bool] = option_show_type,
-    path: Optional[bool] = option_show_path,
-    description: Optional[bool] = option_show_description,
 ):
-    """Display enrichments for an artifact."""
-    assert (
-        sum(bool(i) for i in (type, path, description)) <= 1
-    ), "Can output one key only"
-    infos = gto.api.describe(repo=repo, name=name, rev=rev)
-    if not infos:
-        return
-    d = infos[0].get_object().dict(exclude_defaults=True)
-    if type:
-        if "type" not in d:
-            raise WrongArgs("No type in enrichment")
-        echo(d["type"])
-    elif path:
-        if "path" not in d:
-            raise WrongArgs("No path in enrichment")
-        echo(d["path"])
-    elif description:
-        if "description" not in d:
-            raise WrongArgs("No description in enrichment")
-        echo(d["description"])
-    else:
-        format_echo(d, "json")
+    """Check the registry for inconsistencies."""
+    gto.api._get_state(repo).dict()  # pylint: disable=protected-access
 
 
 if __name__ == "__main__":

--- a/gto/exceptions.py
+++ b/gto/exceptions.py
@@ -27,8 +27,15 @@ class WrongConfig(GTOException):
         super().__init__(self.message)
 
 
+class WrongArtifactsYaml(GTOException):
+    message = "artifacts.yaml file doesn't conform to GTO format"
+
+    def __init__(self) -> None:
+        super().__init__(self.message)
+
+
 class NoFile(GTOException):
-    _message = "No file/folder found in '{path}' for checked out commit"
+    _message = "Nothing found in '{path}' for checked out commit"
 
     def __init__(self, path) -> None:
         self.message = self._message.format(path=path)

--- a/gto/index.py
+++ b/gto/index.py
@@ -9,7 +9,8 @@ from typing import IO, Dict, FrozenSet, Generator, List, Optional, Union
 
 import git
 from git import Repo
-from pydantic import BaseModel, parse_obj_as, validator
+from pydantic import BaseModel, ValidationError, parse_obj_as, validator
+from ruamel.yaml import YAMLError
 
 from gto.base import BaseManager, BaseRegistryState
 from gto.base import Commit as EnrichmentEvent
@@ -31,6 +32,7 @@ from gto.exceptions import (
     NoFile,
     PathIsUsed,
     WrongArgs,
+    WrongArtifactsYaml,
 )
 from gto.ext import EnrichmentInfo, EnrichmentReader
 from gto.git_utils import RemoteRepoMixin, read_repo
@@ -118,10 +120,27 @@ class Index(BaseModel):
 
     @staticmethod
     def read_state(path_or_file: Union[str, IO]):
+        def read_yaml(stream: IO):
+            try:
+                return yaml.load(stream)
+            except YAMLError as e:
+                raise WrongArtifactsYaml() from e
+
+        # read contents of the yaml
         if isinstance(path_or_file, str):
-            with open(path_or_file, "r", encoding="utf8") as file:
-                return parse_obj_as(State, yaml.load(file))
-        state = parse_obj_as(State, yaml.load(path_or_file))
+            try:
+                with open(path_or_file, "r", encoding="utf8") as file:
+                    contents = read_yaml(file)
+            except FileNotFoundError as e:
+                raise NoFile("artifacts.yaml") from e
+        else:
+            contents = read_yaml(path_or_file)
+        # check yaml contents is a valid State
+        try:
+            state = parse_obj_as(State, contents)
+        except ValidationError as e:
+            raise WrongArtifactsYaml() from e
+        # validate that specific names conform to the naming convention
         for key in state:
             assert_name_is_valid(key)
         return state


### PR DESCRIPTION
Close #241 

This just reads repo for now, and prints the error. Basically you can have the same effect if you run `gto show` and `gto describe` for all commits you want.
```
$ gto doctor
❌ artifacts.yaml file doesn't conform to GTO format
```

To consider: in DVC `doctor` have different meaning. 

TODO:
- [x] read checkouted commit
- [ ] read all commits. Support args for (un)selecting all branches/commits?
- [ ] check Git tags as well
- [ ] https://github.com/iterative/gto/issues/142