### PR TITLE
`show` versions registered in specified git ref

### DIFF
--- a/gto/base.py
+++ b/gto/base.py
@@ -9,8 +9,10 @@ from gto.constants import (
     ASSIGNMENTS_PER_VERSION,
     VERSIONS_PER_STAGE,
     Action,
+    Shortcut,
     VersionSort,
 )
+from gto.utils import resolve_ref
 from gto.versions import SemVer
 
 from .exceptions import (
@@ -374,6 +376,21 @@ def sort_versions(
             key=lambda x: get(x, timestamp),
         )[:: 1 if ascending else -1]
     return sorted_versions
+
+
+def filter_versions(repo: git.Repo, versions: List[Version], shortcut: Shortcut):
+    if shortcut.latest:
+        versions = versions[:1]
+    elif shortcut.version:
+        versions = [v for v in versions if shortcut.version == v["version"]]
+    elif shortcut.stage:
+        versions = [
+            v for v in versions for a in v["stages"] if shortcut.stage == a["stage"]
+        ]
+    elif shortcut.ref:
+        commit_hexsha = resolve_ref(repo, shortcut.ref).hexsha
+        versions = [v for v in versions if commit_hexsha == v["commit_hexsha"]]
+    return versions
 
 
 class Artifact(BaseObject):

--- a/gto/cli.py
+++ b/gto/cli.py
@@ -845,11 +845,14 @@ def show(  # pylint: disable=too-many-locals
         arg = "stage" if show_stage else arg
         arg = "ref" if show_ref else arg
         if arg:
-            if arg not in output[0][0]:
-                raise WrongArgs(f"Cannot apply --{arg}")
-            format_echo(
-                [v[arg] if isinstance(v, dict) else v for v in output[0]], "lines"
-            )
+            if output[0]:
+                if arg not in output[0][0]:
+                    raise WrongArgs(f"Cannot apply --{arg}")
+                format_echo(
+                    [v[arg] if isinstance(v, dict) else v for v in output[0]], "lines"
+                )
+            else:
+                format_echo([], "lines")
         else:
             format_echo(
                 output,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -146,6 +146,46 @@ def test_commands(showcase):
         ["-r", path, "rf#production", "--ref"],
         "rf@v1.2.3\n",
     )
+    _check_successful_cmd(
+        "show",
+        ["-r", path, "nn", "--ro", "--ref"],
+        "nn@v0.0.1\n",
+    )
+    _check_successful_cmd(
+        "show",
+        ["-r", path, "#production", "--ref"],
+        "rf@v1.2.3\n",
+    )
+    _check_successful_cmd(
+        "show",
+        ["-r", path, "#staging", "--ref"],
+        "nn@v0.0.1\n" "rf@v1.2.4\n",
+    )
+    _check_successful_cmd(
+        "show",
+        ["-r", path, ":HEAD", "--ref", "--ro"],
+        "rf@v1.2.4\n",
+    )
+    _check_successful_cmd(
+        "show",
+        ["-r", path, "nn:HEAD", "--ref", "--ro"],
+        "",
+    )
+    _check_successful_cmd(
+        "show",
+        ["-r", path, "rf:HEAD", "--ref", "--ro"],
+        "rf@v1.2.4\n",
+    )
+    _check_successful_cmd(
+        "show",
+        ["-r", path, "@v1.2.4", "--ref"],
+        "rf@v1.2.4\n",
+    )
+    _check_successful_cmd(
+        "show",
+        ["-r", path, "--long"],
+        None,
+    )
     _check_successful_cmd("describe", ["-r", path, "artifactnotexist"], "")
     _check_successful_cmd("describe", ["-r", path, "rf#stagenotexist"], "")
     _check_successful_cmd("describe", ["-r", path, "rf"], EXPECTED_DESCRIBE_OUTPUT)

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -1,6 +1,6 @@
 import pytest
 
-from gto.constants import check_name_is_valid
+from gto.constants import Shortcut, check_name_is_valid, parse_shortcut
 
 
 @pytest.mark.parametrize(
@@ -39,3 +39,24 @@ def test_check_name_is_valid(name):
 )
 def test_check_name_is_invalid(name):
     assert not check_name_is_valid(name)
+
+
+@pytest.mark.parametrize(
+    "name,shortcut",
+    [
+        ("", None),
+        ("m", None),
+        ("m/", None),
+        ("nn", None),
+        ("model@v1.2.3", Shortcut(name="model", version="v1.2.3")),
+        ("model#prod", Shortcut(name="model", stage="prod")),
+        ("model:HEAD", Shortcut(name="model", ref="HEAD")),
+        (":HEAD", Shortcut(name=None, ref="HEAD")),
+        ("@v1.2.3", Shortcut(name=None, version="v1.2.3")),
+        ("#prod", Shortcut(name=None, stage="prod")),
+        # ("model:HEAD#prod", Shortcut(name="model", ref="HEAD", stage="prod")),
+        # ("model#prod:HEAD", Shortcut(name="model", ref="HEAD", stage="prod")),
+    ],
+)
+def test_parse_shortcut(name, shortcut):
+    assert parse_shortcut(name) == shortcut


### PR DESCRIPTION
close https://github.com/iterative/gto/issues/312

Implements https://github.com/iterative/gto/issues/312#issuecomment-1378293368:

```shell
$ git clone https://github.com/iterative/example-gto
$ cd example-gto
$ gto show
╒══════════╤══════════╤════════╤═════════╤════════════╕
│ name     │ latest   │ #dev   │ #prod   │ #staging   │
╞══════════╪══════════╪════════╪═════════╪════════════╡
│ churn    │ v3.1.1   │ v3.1.1 │ v3.0.0  │ v3.1.0     │
│ cv-class │ v0.1.13  │ -      │ -       │ -          │
│ segment  │ v0.4.1   │ v0.4.1 │ -       │ -          │
╘══════════╧══════════╧════════╧═════════╧════════════╛
$ gto show nn:HEAD  # show versions for nn in HEAD
╒════════════╤═══════════╤═════════╤═════════════════════╤══════════════╕
│ artifact   │ version   │ stage   │ created_at          │ ref          │
╞════════════╪═══════════╪═════════╪═════════════════════╪══════════════╡
│ churn      │ v3.1.0    │ staging │ 2022-11-20 09:36:38 │ churn@v3.1.0 │
╘════════════╧═══════════╧═════════╧═════════════════════╧══════════════╛
$ gto show nn:HEAD --ref
churn@v3.1.0
$ gto show :HEAD  # show all artifacts that have versions/assignments in HEAD
╒════════════╤═══════════╤═════════╤═════════════════════╤══════════════╕
│ artifact   │ version   │ stage   │ created_at          │ ref          │
╞════════════╪═══════════╪═════════╪═════════════════════╪══════════════╡
│ churn      │ v3.1.0    │ staging │ 2022-11-20 09:36:38 │ churn@v3.1.0 │
╘════════════╧═══════════╧═════════╧═════════════════════╧══════════════╛
$ gto show @v3.1.0  # show all v3.1.0 versions for all artifacts
╒════════════╤═══════════╤═════════╤═════════════════════╤══════════════╕
│ artifact   │ version   │ stage   │ created_at          │ ref          │
╞════════════╪═══════════╪═════════╪═════════════════════╪══════════════╡
│ churn      │ v3.1.0    │ staging │ 2022-11-20 09:36:38 │ churn@v3.1.0 │
╘════════════╧═══════════╧═════════╧═════════════════════╧══════════════╛
$ gto show "#staging"  # show all versions in staging for all artifacts
╒════════════╤═══════════╤═════════╤═════════════════════╤══════════════╕
│ artifact   │ version   │ stage   │ created_at          │ ref          │
╞════════════╪═══════════╪═════════╪═════════════════════╪══════════════╡
│ churn      │ v3.1.0    │ staging │ 2022-11-20 09:36:38 │ churn@v3.1.0 │
╘════════════╧═══════════╧═════════╧═════════════════════╧══════════════╛
$ gto show --long  # alternative way to show the registry
╒════════════╤═══════════╤═════════╤═════════════════════╤══════════════╕
│ artifact   │ version   │ stage   │ created_at          │ ref          │
╞════════════╪═══════════╪═════════╪═════════════════════╪══════════════╡
│ churn      │ v3.1.1    │ dev     │ 2022-11-27 08:16:38 │ churn@v3.1.1 │
│ churn      │ v3.1.0    │ staging │ 2022-11-20 09:36:38 │ churn@v3.1.0 │
│ churn      │ v3.0.0    │ prod    │ 2022-11-15 18:29:58 │ churn@v3.0.0 │
│ cv-class   │ v0.1.13   │         │ 2022-11-18 02:03:18 │ cv-class@v0.1.13 │
│ cv-class   │ 793ff78   │         │ 2022-11-19 05:49:58 │ 793ff78          │
│ segment    │ v0.4.1    │ dev     │ 2022-11-16 22:16:38 │ segment@v0.4.1 │
│ segment    │ 793ff78   │         │ 2022-11-19 05:49:58 │ 793ff78        │
╘════════════╧═══════════╧═════════╧═════════════════════╧════════════════╛
```