### PR TITLE
Fix CI - Bump isort to 5.12.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,7 +33,7 @@ repos:
     hooks:
       - id: black
   - repo: 'https://github.com/PyCQA/isort'
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
       - id: isort
         args: ["--profile", "black"]


### PR DESCRIPTION
Fix pre-commit config

Link to issue: https://github.com/home-assistant/core/issues/86892