### PR TITLE
Migrate from PyPI tokens to Trusted Publishers

### DIFF
--- a/.github/workflows/check-test-release.yml
+++ b/.github/workflows/check-test-release.yml
@@ -68,13 +68,13 @@ jobs:
         fail_ci_if_error: false
         token: ${{ secrets.CODECOV_TOKEN }}
   deploy:
-    environment: pypi
     name: PyPI Deploy
     needs: [check, test]
-    runs-on: ubuntu-latest
+    environment: pypi
     permissions:
       contents: write
       id-token: write
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
       with:

--- a/.github/workflows/check-test-release.yml
+++ b/.github/workflows/check-test-release.yml
@@ -68,11 +68,13 @@ jobs:
         fail_ci_if_error: false
         token: ${{ secrets.CODECOV_TOKEN }}
   deploy:
+    environment: pypi
     name: PyPI Deploy
     needs: [check, test]
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      id-token: write
     steps:
     - uses: actions/checkout@v4
       with:
@@ -80,12 +82,12 @@ jobs:
     - uses: actions/setup-python@v4
       with:
         python-version: '3.10'
-    - id: dist
-      uses: casperdcl/deploy-pypi@v2
+    - uses: casperdcl/deploy-pypi@v2
       with:
         build: true
-        password: ${{ secrets.PYPI_TOKEN }}
-        upload: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags') }}
+        upload: false
+    - if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+      uses: pypa/gh-action-pypi-publish@release/v1
     - id: meta
       name: Changelog
       run: |


### PR DESCRIPTION
https://blog.pypi.org/posts/2023-04-20-introducing-trusted-publishers#using-trusted-publishing-with-github-actions