### PR TITLE
support pydantic v2

### DIFF
--- a/gto/_pydantic.py
+++ b/gto/_pydantic.py
@@ -1,0 +1,30 @@
+__all__ = [
+    "BaseModel",
+    "BaseSettings",
+    "ValidationError",
+    "parse_obj_as",
+    "validator",
+    "InitSettingsSource",
+]
+
+
+try:
+    from pydantic.v1 import (
+        BaseModel,
+        BaseSettings,
+        ValidationError,
+        parse_obj_as,
+        validator,
+    )
+    from pydantic.v1.env_settings import InitSettingsSource
+except ImportError:
+    from pydantic import (  # type: ignore[no-redef,assignment]
+        BaseModel,
+        BaseSettings,
+        ValidationError,
+        parse_obj_as,
+        validator,
+    )
+    from pydantic.env_settings import (  # type: ignore[no-redef,assignment]
+        InitSettingsSource,
+    )

--- a/gto/base.py
+++ b/gto/base.py
@@ -1,7 +1,6 @@
 from datetime import datetime
 from typing import Any, Dict, FrozenSet, List, Optional, Sequence, Union
 
-from pydantic import BaseModel
 from scmrepo.git import Git
 
 from gto.config import RegistryConfig
@@ -13,6 +12,7 @@ from gto.constants import (
 )
 from gto.versions import SemVer
 
+from ._pydantic import BaseModel
 from .exceptions import (
     ArtifactNotFound,
     ManyVersions,

--- a/gto/config.py
+++ b/gto/config.py
@@ -3,13 +3,13 @@ import pathlib
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
-from pydantic import BaseModel, BaseSettings, validator
-from pydantic.env_settings import InitSettingsSource
 from ruamel.yaml import YAML
 
 from gto.constants import assert_name_is_valid
 from gto.exceptions import UnknownStage, UnknownType, WrongConfig
 from gto.ext import EnrichmentReader, find_enrichment_types, find_enrichments
+
+from ._pydantic import BaseModel, BaseSettings, InitSettingsSource, validator
 
 yaml = YAML(typ="safe", pure=True)
 yaml.default_flow_style = False
@@ -27,8 +27,8 @@ class EnrichmentConfig(BaseModel):
 
 class NoFileConfig(BaseSettings):  # type: ignore[valid-type]
     INDEX: str = "artifacts.yaml"
-    TYPES: Optional[List[str]]
-    STAGES: Optional[List[str]]
+    TYPES: Optional[List[str]] = None
+    STAGES: Optional[List[str]] = None
     LOG_LEVEL: str = "INFO"
     DEBUG: bool = False
     ENRICHMENTS: List[EnrichmentConfig] = []
@@ -41,11 +41,13 @@ class NoFileConfig(BaseSettings):  # type: ignore[valid-type]
 
     def assert_type(self, name):
         assert_name_is_valid(name)
+        # pylint: disable-next=unsupported-membership-test
         if self.TYPES is not None and name not in self.TYPES:
             raise UnknownType(name, self.TYPES)
 
     def assert_stage(self, name):
         assert_name_is_valid(name)
+        # pylint: disable-next=unsupported-membership-test
         if self.STAGES is not None and name not in self.STAGES:
             raise UnknownStage(name, self.STAGES)
 

--- a/gto/constants.py
+++ b/gto/constants.py
@@ -2,9 +2,9 @@ import re
 from enum import Enum
 from typing import Optional
 
-from pydantic import BaseModel
-
 from gto.exceptions import ValidationError
+
+from ._pydantic import BaseModel
 
 COMMIT = "commit"
 REF = "ref"

--- a/gto/ext.py
+++ b/gto/ext.py
@@ -4,8 +4,9 @@ from importlib import import_module
 from typing import Dict, Optional, Type, Union
 
 import entrypoints
-from pydantic import BaseModel
 from scmrepo.git import Git
+
+from ._pydantic import BaseModel
 
 ENRICHMENT_ENTRYPOINT = "gto.enrichment"
 

--- a/gto/index.py
+++ b/gto/index.py
@@ -19,7 +19,6 @@ from typing import (
     Union,
 )
 
-from pydantic import BaseModel, ValidationError, parse_obj_as, validator
 from ruamel.yaml import YAMLError
 from scmrepo.exceptions import SCMError
 from scmrepo.git import Git
@@ -50,6 +49,8 @@ from gto.exceptions import (
 from gto.ext import EnrichmentInfo, EnrichmentReader
 from gto.git_utils import RemoteRepoMixin
 from gto.ui import echo
+
+from ._pydantic import BaseModel, ValidationError, parse_obj_as, validator
 
 logger = logging.getLogger("gto")
 

--- a/gto/registry.py
+++ b/gto/registry.py
@@ -4,7 +4,6 @@ from contextlib import contextmanager
 from typing import List, Optional, TypeVar, cast
 
 from funcy import distinct
-from pydantic import BaseModel
 from scmrepo.git import Git
 
 from gto.base import (
@@ -36,6 +35,8 @@ from gto.tag import (
 )
 from gto.ui import echo
 from gto.versions import SemVer
+
+from ._pydantic import BaseModel
 
 TBaseEvent = TypeVar("TBaseEvent", bound=BaseEvent)
 

--- a/gto/tag.py
+++ b/gto/tag.py
@@ -4,10 +4,10 @@ from datetime import datetime
 from enum import Enum
 from typing import FrozenSet, Iterable, Optional, Union
 
-from pydantic import BaseModel
 from scmrepo.exceptions import RevError
 from scmrepo.git import Git, GitTag
 
+from ._pydantic import BaseModel
 from .base import (
     Artifact,
     Assignment,

--- a/gto/utils.py
+++ b/gto/utils.py
@@ -6,10 +6,11 @@ from datetime import datetime
 from enum import Enum
 
 import click
-from pydantic import BaseModel
 from tabulate import tabulate
 
 from gto.config import yaml
+
+from ._pydantic import BaseModel
 
 
 def flatten(obj):

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,9 @@ install_requires = [
     "scmrepo>=1.3.1,<2",
     "typer>=0.4.1",
     "rich",
-    "pydantic>=1.9.0,<2",
+    # pydantic.v1.parse_obj is broken in ==2.0.0:
+    # https://github.com/pydantic/pydantic/issues/6361
+    "pydantic>=1.9.0,!=2.0.0",
     "ruamel.yaml",
     "semver>=3.0.0",
     "entrypoints",

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -3,7 +3,8 @@ from copy import deepcopy
 from typing import Any, Dict, Sequence, Set, Union
 
 from funcy import omit
-from pydantic import BaseModel
+
+from gto._pydantic import BaseModel
 
 
 def show_difference(left: Dict, right: Dict):


### PR DESCRIPTION
Also supports pydantic v1.

pydantic v2 provides v1 api through `pydantic.v1` import, so we can support both versions by trying to import from `pydantic.v1` and fallback to old behaviour.

See https://docs.pydantic.dev/latest/migration/#continue-using-pydantic-v1-features.

pydantic == 2.0.0 does not work due to https://github.com/pydantic/pydantic/issues/6361, so we need to blacklist that specific version.