### PR TITLE
fix(registry): push to remote automatically only on cloned repos

### DIFF
--- a/gto/api.py
+++ b/gto/api.py
@@ -19,7 +19,6 @@ from gto.constants import (
     parse_shortcut,
 )
 from gto.exceptions import NoRepo, NotImplementedInGTO, RefNotFound, WrongArgs
-from gto.git_utils import has_remote
 from gto.index import Artifact, RepoIndexManager
 from gto.registry import GitRegistry
 from gto.tag import parse_name as parse_tag_name
@@ -97,7 +96,7 @@ def register(
             bump_major=bump_major,
             bump_minor=bump_minor,
             bump_patch=bump_patch,
-            push=push or has_remote(reg.scm),
+            push=push,
             stdout=stdout,
             author=author,
             author_email=author_email,
@@ -131,7 +130,7 @@ def assign(
             message=message,
             simple=simple,
             force=force,
-            push=push or has_remote(reg.scm),
+            push=push,
             skip_registration=skip_registration,
             stdout=stdout,
             author=author,
@@ -165,7 +164,7 @@ def unassign(
             simple=simple if simple is not None else False,
             force=force,
             delete=delete,
-            push=push or has_remote(reg.scm),
+            push=push,
             author=author,
             author_email=author_email,
         )
@@ -195,7 +194,7 @@ def deregister(
             simple=simple if simple is not None else True,
             force=force,
             delete=delete,
-            push=push or has_remote(reg.scm),
+            push=push,
             author=author,
             author_email=author_email,
         )
@@ -223,7 +222,7 @@ def deprecate(
             simple=simple,
             force=force,
             delete=delete,
-            push=push or has_remote(reg.scm),
+            push=push,
             author=author,
             author_email=author_email,
         )

--- a/gto/cli.py
+++ b/gto/cli.py
@@ -375,7 +375,7 @@ option_push_tag = Option(
     False,
     "--push",
     is_flag=True,
-    help="Push created git tag to `origin` (done automatically for remote repo)",
+    help="Push created git tag to `origin` (ignored if `repo` option is a remote URL)",
 )
 option_commit = Option(
     False,

--- a/setup.py
+++ b/setup.py
@@ -24,8 +24,6 @@ tests = [
     "pytest-mock",
     "pytest-test-utils",
     "pylint==2.17.5",
-    # we use this to suppress pytest-related false positives in our tests.
-    "pylint-pytest",
     # we use this to suppress some messages in tests, eg: foo/bar naming,
     # and, protected method calls in our tests
     "pylint-plugin-utils",

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -1,6 +1,7 @@
 from typing import Sequence
 
 import pytest
+from pytest_mock import MockFixture
 from pytest_test_utils import TmpDir
 from scmrepo.git import Git
 
@@ -111,3 +112,17 @@ def test_check_existence_no_repo(tmp_dir: TmpDir):
     tmp_dir.gen("m1.txt", "some content")
     assert check_if_path_exists(tmp_dir / "m1.txt")
     assert not check_if_path_exists(tmp_dir / "not" / "exists")
+
+
+def test_from_url_sets_cloned_property(tmp_dir: TmpDir, scm: Git, mocker: MockFixture):
+    with RepoIndexManager.from_url(tmp_dir) as idx:
+        assert idx.cloned is False
+
+    with RepoIndexManager.from_url(scm) as idx:
+        assert idx.cloned is False
+
+    cloned_git_repo_mock = mocker.patch("gto.git_utils.cloned_git_repo")
+    cloned_git_repo_mock.return_value.__enter__.return_value = scm
+
+    with RepoIndexManager.from_url("https://github.com/iterative/gto") as idx:
+        assert idx.cloned is True


### PR DESCRIPTION
Fixes #405 

We've changed the semantic of the operation during the recent migration to `scmrepo`. The key thing is the `has_remote(reg.scm)` calls and implementation. I think the original intention was to push automatically when we run GTO operations on a remote repo (means we are cloning it into a temp dir, do some op, and push the result back).

## TODO

- [x] Tests
- [x] Review CLI option description
- [x] Review docs

## Docs

Relevant docs update is here https://github.com/iterative/dvc.org/pull/4879