### PR TITLE
fix(tags): parse timezone information from a tag

### DIFF
--- a/gto/index.py
+++ b/gto/index.py
@@ -3,7 +3,6 @@ import os
 from abc import ABC, abstractmethod
 from collections import defaultdict
 from contextlib import contextmanager
-from datetime import datetime
 from functools import wraps
 from pathlib import Path
 from typing import (
@@ -524,7 +523,7 @@ class EnrichmentManager(BaseManager, RemoteRepoMixin):
                     EnrichmentEvent(
                         artifact=artifact.artifact,
                         version=version.version,
-                        created_at=datetime.fromtimestamp(commit.commit_time),
+                        created_at=commit.commit_datetime,
                         author=commit.author_name,
                         author_email=commit.author_email,
                         commit_hexsha=commit.hexsha,
@@ -548,7 +547,7 @@ class EnrichmentManager(BaseManager, RemoteRepoMixin):
                     EnrichmentEvent(
                         artifact=artifact.artifact,
                         version=version.version,
-                        created_at=datetime.fromtimestamp(commit.commit_time),
+                        created_at=commit.commit_datetime,
                         author=commit.author_name,
                         author_email=commit.author_email,
                         commit_hexsha=commit.hexsha,

--- a/gto/tag.py
+++ b/gto/tag.py
@@ -1,6 +1,6 @@
+import datetime
 import os
 import re
-from datetime import datetime
 from enum import Enum
 from typing import FrozenSet, Iterable, Optional, Union
 
@@ -124,7 +124,7 @@ class Tag(BaseModel):
     name: str
     version: Optional[str]
     stage: Optional[str]
-    created_at: datetime
+    created_at: datetime.datetime
     tag: GitTag
 
     class Config:
@@ -134,7 +134,7 @@ class Tag(BaseModel):
 def parse_tag(tag: GitTag):
     return Tag(
         tag=tag,
-        created_at=datetime.fromtimestamp(tag.tag_time),
+        created_at=tag.tag_datetime,
         **parse_name(tag.name),
     )
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from setuptools import find_packages, setup
 
 install_requires = [
-    "scmrepo>=1.3.1,<2",
+    "scmrepo>=1.4.0,<2",
     "typer>=0.4.1",
     "rich",
     # pydantic.v1.parse_obj is broken in ==2.0.0:

--- a/tests/resources/sample_remote_repo_expected_history_churn.json
+++ b/tests/resources/sample_remote_repo_expected_history_churn.json
@@ -1,6 +1,6 @@
 [
   {
-    "timestamp": "2022-05-26 23:49:52",
+    "timestamp": "2022-05-27 02:49:52+03:00",
     "artifact": "churn",
     "event": "assignment",
     "priority": 5,
@@ -13,7 +13,7 @@
     "ref": "churn#prod#2"
   },
   {
-    "timestamp": "2022-05-25 20:03:12",
+    "timestamp": "2022-05-25 23:03:12+03:00",
     "artifact": "churn",
     "event": "assignment",
     "priority": 5,
@@ -26,7 +26,7 @@
     "ref": "churn#staging#1"
   },
   {
-    "timestamp": "2022-05-24 16:16:32",
+    "timestamp": "2022-05-24 19:16:32+03:00",
     "artifact": "churn",
     "event": "registration",
     "priority": 3,
@@ -39,7 +39,7 @@
     "ref": "churn@v3.1.0"
   },
   {
-    "timestamp": "2022-05-20 01:09:52",
+    "timestamp": "2022-05-20 04:09:52+03:00",
     "artifact": "churn",
     "event": "registration",
     "priority": 3,

--- a/tests/test_tag.py
+++ b/tests/test_tag.py
@@ -3,7 +3,7 @@ from scmrepo.git import Git
 
 from gto.constants import Action
 from gto.exceptions import RefNotFound, TagExists
-from gto.tag import create_tag, find, name_tag, parse_name
+from gto.tag import create_tag, find, name_tag, parse_name, parse_tag
 
 
 def test_name_tag(scm: Git):
@@ -148,3 +148,11 @@ def test_create_tag_repeated_tagname(scm: Git):
 def test_lightweight_tag(scm: Git):
     scm.tag("lightweight-tag@v0.0.1")
     assert find(scm=scm) == []
+
+
+@pytest.mark.usefixtures("repo_with_commit")
+def test_parse_tag_created_at_timezone(scm: Git):
+    create_tag(scm, "nn#prod", rev="HEAD", message="msg")
+    tag = parse_tag(scm.get_tag("nn#prod"))
+    d = tag.created_at
+    assert d.tzinfo is not None and d.tzinfo.utcoffset(d) is not None


### PR DESCRIPTION
We don't parse timezones, means we are not getting right dates in Studio. Also Studio tests produce a lot of warning about "naive" date times.

Not critical, but better to fix in advance.
