### PR TITLE
gha: don't wait on check/tests to release

### DIFF
--- a/.github/workflows/check-test-release.yml
+++ b/.github/workflows/check-test-release.yml
@@ -69,7 +69,6 @@ jobs:
         token: ${{ secrets.CODECOV_TOKEN }}
   deploy:
     name: PyPI Deploy
-    needs: [check, test]
     environment: pypi
     permissions:
       contents: write


### PR DESCRIPTION
Stuff might be flaky or super slow. All the testing that we need is done during development/PRs, no good reason to throttle it.