### PR TITLE
Loosen semver dep to make it azure-cli compatible

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ install_requires = [
     # https://github.com/pydantic/pydantic/issues/6361
     "pydantic>=1.9.0,<3,!=2.0.0",
     "ruamel.yaml",
-    "semver==2.13.0",
+    "semver>=2.13.0",
     "entrypoints",
     "tabulate>=0.8.10",
     "funcy",

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ install_requires = [
     # https://github.com/pydantic/pydantic/issues/6361
     "pydantic>=1.9.0,<3,!=2.0.0",
     "ruamel.yaml",
-    "semver>=3.0.0",
+    "semver==2.13.0",
     "entrypoints",
     "tabulate>=0.8.10",
     "funcy",


### PR DESCRIPTION
`azure-cli` still strictly depends on the 2.13.0 and we can't install it along with DVC (in some environments it still the easiest way). It seems we don't care about 3.0 specifically, so, let's try to loosen it a bit.