### PR TITLE
chore(deps): drop Python 3.9, add 3.14, consolidate dependency updates

### DIFF
--- a/.github/workflows/check-test-release.yml
+++ b/.github/workflows/check-test-release.yml
@@ -26,10 +26,10 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v7
       with:
         fetch-depth: 0
 
@@ -44,7 +44,7 @@ jobs:
     - run: pytest
 
     - name: "Upload coverage to Codecov"
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@v7
       with:
         fail_ci_if_error: false
         token: ${{ secrets.CODECOV_TOKEN }}
@@ -59,12 +59,12 @@ jobs:
       id-token: write
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v7
       with:
         fetch-depth: 0
     - uses: actions/setup-python@v6
       with:
-        python-version: '3.13'
+        python-version: '3.14'
 
     - run: pip install build twine
     - run: python -m build

--- a/gto/api.py
+++ b/gto/api.py
@@ -364,6 +364,7 @@ def _show_registry(
                     d["version"],
                 ]
                 + [d["stage"][name] for name in stages],
+                strict=False,
             ),
         )
         for name, d in sorted(models_state.items())

--- a/gto/api.py
+++ b/gto/api.py
@@ -364,7 +364,7 @@ def _show_registry(
                     d["version"],
                 ]
                 + [d["stage"][name] for name in stages],
-                strict=False,
+                strict=True,
             ),
         )
         for name, d in sorted(models_state.items())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,10 +32,10 @@ dependencies = [
     "scmrepo>=3,<4",
     "semver>=2.13.0",
     "tabulate>=0.8.10",
-    # typer>=0.24 vendors click and is incompatible with gto's click-based
+    # typer>=0.26 vendors click and is incompatible with gto's click-based
     # CLI machinery (subclassing click.Command, @click.pass_context, etc.):
     # the CLI crashes on startup. Migration tracked separately.
-    "typer>=0.4.1,<0.24",
+    "typer>=0.4.1,<0.26",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,15 +12,17 @@ keywords = ["git", "repo", "repository", "artifact", "registry", "developer-tool
 classifiers = [
     "Development Status :: 2 - Pre-Alpha",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
 ]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dynamic = ["version"]
 dependencies = [
+    # gto imports click directly, so declare it explicitly
+    "click>=8,<9",
     "entrypoints",
     "funcy",
     "pydantic>=2",
@@ -30,7 +32,10 @@ dependencies = [
     "scmrepo>=3,<4",
     "semver>=2.13.0",
     "tabulate>=0.8.10",
-    "typer>=0.4.1",
+    # typer>=0.24 vendors click and is incompatible with gto's click-based
+    # CLI machinery (subclassing click.Command, @click.pass_context, etc.):
+    # the CLI crashes on startup. Migration tracked separately.
+    "typer>=0.4.1,<0.24",
 ]
 
 [project.urls]
@@ -48,11 +53,8 @@ tests = [
 ]
 dev = [
     "gto[tests]",
-    "mypy==1.17.1; python_version > '3.9'",
-    # mypy>=1.11.0 crashes when used with pydantic-settings on Python 3.9,
-    # see: https://github.com/python/mypy/issues/17535
-    "mypy<1.11.0; python_version <= '3.9'",
-    "pylint==3.3.8",
+    "mypy==2.2.0",
+    "pylint==4.0.6",
     "types-PyYAML",
     "types-filelock",
     "types-freezegun",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,4 @@
 # pylint: disable=redefined-outer-name
-import inspect
 import os
 import sys
 from time import sleep
@@ -19,13 +18,7 @@ from gto.config import CONFIG_FILE_NAME
 
 class Runner:
     def __init__(self):
-        # Older versions of CliRunner need this
-        # Can we removed when we drop Py 3.9 support
-        init_sig = inspect.signature(CliRunner.__init__)
-        if "mix_stderr" in init_sig.parameters:
-            self._runner = CliRunner(mix_stderr=False)  # pylint: disable=unexpected-keyword-arg
-        else:
-            self._runner = CliRunner()
+        self._runner = CliRunner()
 
     def invoke(self, *args, **kwargs) -> Result:
         return self._runner.invoke(app, *args, **kwargs)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -298,7 +298,7 @@ def test_check_ref_catch_the_bug(scm: Git):
     for assignment, tag in zip(
         [assignment1, assignment2, assignment3],
         [f"{NAME}#staging#1", f"{NAME}#prod#2", f"{NAME}#dev#3"],
-        strict=False,
+        strict=True,
     ):
         events = gto.api.check_ref(scm, tag)
         assert len(events) == 1, events

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -298,6 +298,7 @@ def test_check_ref_catch_the_bug(scm: Git):
     for assignment, tag in zip(
         [assignment1, assignment2, assignment3],
         [f"{NAME}#staging#1", f"{NAME}#prod#2", f"{NAME}#dev#3"],
+        strict=False,
     ):
         events = gto.api.check_ref(scm, tag)
         assert len(events) == 1, events

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -431,6 +431,7 @@ def test_registry_state_tag_tag(tmp_dir: TmpDir):
         for appeared, expected in zip(
             iter_over(appeared_state["artifacts"][artifact]["versions"]),
             iter_over(expected_state["artifacts"][artifact]["versions"]),
+            strict=False,
         ):
             check_obj(appeared, expected, exclude["versions"])
 
@@ -438,6 +439,7 @@ def test_registry_state_tag_tag(tmp_dir: TmpDir):
                 for a, e in zip(
                     iter_over(appeared[key]),
                     iter_over(expected[key]),
+                    strict=False,
                 ):
                     check_obj(a, e, exclude[key])
 

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -431,7 +431,7 @@ def test_registry_state_tag_tag(tmp_dir: TmpDir):
         for appeared, expected in zip(
             iter_over(appeared_state["artifacts"][artifact]["versions"]),
             iter_over(expected_state["artifacts"][artifact]["versions"]),
-            strict=False,
+            strict=True,
         ):
             check_obj(appeared, expected, exclude["versions"])
 
@@ -439,7 +439,7 @@ def test_registry_state_tag_tag(tmp_dir: TmpDir):
                 for a, e in zip(
                     iter_over(appeared[key]),
                     iter_over(expected[key]),
-                    strict=False,
+                    strict=True,
                 ):
                     check_obj(a, e, exclude[key])
 


### PR DESCRIPTION
Consolidates all open Renovate deps/chore PRs into one change, fixes the CI breakage on `main`, and moves the supported Python range to 3.10–3.14.

## Why main was red

The weekly runs on `main` have been failing on Python 3.10+ since early June. Root cause: **typer ≥0.26 vendors click** and no longer depends on it, so fresh installs stopped pulling click in — while gto imports `click` directly (`gto/cli.py`, `gto/utils.py`, `tests/conftest.py`) without declaring it. pylint failed with `E0401: Unable to import 'click'`.

It's worse than lint: gto's CLI machinery subclasses real-click classes (`GtoCliMixin(click.Command)`, `@click.pass_context`) and mixes them into typer's (now vendored-click) `TyperCommand`/`TyperGroup` MROs. With typer 0.26.x even `gto --help` crashes on startup (`TypeError: Command.__init__() got an unexpected keyword argument 'rich_markup_mode'`) — i.e. a fresh `pip install gto` on Python 3.10+ currently yields a broken CLI. Python 3.9 was unaffected only because it resolves typer 0.23.2 (0.24+ requires Python ≥3.10; all pre-0.26 versions depend on real click).

**Fix:** declare `click>=8,<9` explicitly and pin `typer>=0.4.1,<0.26`. Migrating to vendored-click typer (≥0.26) requires reworking the CLI help/exception machinery against `typer._click` and should be tracked as a separate effort.

## Python support

- Drop Python 3.9 (EOL October 2025): removed from test matrix, classifiers; `requires-python = ">=3.10"`
- Add Python 3.14 to the test matrix and classifiers
- Remove the `CliRunner` `mix_stderr` shim in `tests/conftest.py` (only needed for the old click that py3.9 resolved)
- `zip(..., strict=False)` fixes auto-applied by ruff `B905`, which activates with the 3.10+ target

## Consolidated Renovate updates

| PR | Update | Resolution |
|---|---|---|
| #496 | `actions/checkout` v5 → v7 | taken as-is |
| #493 | `codecov/codecov-action` v4 → v7 | taken as-is |
| #484 | deploy job Python 3.13 → 3.14 | taken, plus 3.14 in test matrix |
| #487 | pylint 3.3.8 → 4.0.6 | taken (pylint 4 requires ≥3.10 — unblocked by the 3.9 drop) |
| #482 | pylint → 3.3.9 | superseded by #487 |
| #495 | mypy → v2 | delivered as `mypy==2.2.0` (the py3.9-only `<1.11.0` pin is gone with 3.9) |
| #494 | mypy → `<1.20.3` | superseded by #495 |

## Verification

Ran locally on macOS for Python **3.10**, **3.13**, and **3.14**, each with a fresh venv:

- `pip install -e .[dev]` resolves cleanly (click 8.4.2, typer 0.23.2, mypy 2.2.0, pylint 4.0.6, pygit2 1.19.3)
- `pre-commit run --all-files` — all hooks pass (ruff, ruff-format, mypy 2.2.0, pylint 4.0.6)
- `pytest` — 165 passed on each
- `gto --help` / `gto show` / `gto --version` work (broken before on 3.10+ with unpinned typer)
- `python -m build && twine check --strict dist/*` passes on 3.14 (deploy job path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
