### PR TITLE
fix: strip trailing newlines from show line output

### DIFF
--- a/gto/utils.py
+++ b/gto/utils.py
@@ -47,6 +47,10 @@ def make_ready_to_serialize(
     )
 
 
+def _format_line_value(value):
+    return str(value).rstrip("\r\n")
+
+
 def format_echo(result, format, format_table=None, if_empty="", missing_value="-"):
     if format == "yaml":
         yaml.dump(make_ready_to_serialize(result), sys.stdout)
@@ -69,9 +73,9 @@ def format_echo(result, format, format_table=None, if_empty="", missing_value="-
     elif format == "lines":
         if result:
             for line in result:
-                click.echo(line)
+                click.echo(_format_line_value(line))
     elif format == "line":
         if result:
-            click.echo(result)
+            click.echo(_format_line_value(result))
     else:
         raise NotImplementedError(f"Format {format} is not implemented")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -502,6 +502,14 @@ def test_show_line_flag_empty_result():
         _check_successful_cmd("show", ["-r", ".", "m5#missing", "--version"], "")
 
 
+def test_show_line_flags_strip_value_newlines():
+    output = ([{"ref": "rf@v1.2.4\n", "version": "v1.2.4\r\n"}], "keys")
+    with mock.patch("gto.api.show", return_value=output):
+        _check_successful_cmd("show", ["-r", ".", "rf@latest", "--ref"], "rf@v1.2.4\n")
+    with mock.patch("gto.api.show", return_value=output):
+        _check_successful_cmd("show", ["-r", ".", "rf@latest", "--version"], "v1.2.4\n")
+
+
 def test_history_json_empty(repo_with_commit: str):
     _check_successful_cmd("history", ["-r", repo_with_commit, "--json"], "[]\n")
 


### PR DESCRIPTION
## Summary

Fixes #454 by normalizing `gto show` single-line outputs so tag/ref/version values that already contain trailing CR/LF characters do not produce an extra blank line in CLI output.

## Changes

- Strip trailing `\r`/`\n` from values emitted through `format_echo(..., \"line\")` and `format_echo(..., \"lines\")`.
- Keep Click's normal single terminating newline for terminal-friendly output.
- Add a regression test covering `gto show --ref` and `gto show --version` when returned values contain trailing newlines.

## Verification

- `pytest tests/test_cli.py::test_show_line_flags_strip_value_newlines tests/test_cli.py::test_commands tests/test_cli.py::test_show_ref_flag_not_applicable -q`
- `pytest -q`
  - 189 passed, 1 warning
- `python -m py_compile gto/*.py`
- `git diff --check`