### PR TITLE
fix: handle empty show line results

### DIFF
--- a/gto/cli.py
+++ b/gto/cli.py
@@ -732,6 +732,8 @@ def show(  # pylint: disable=too-many-locals
         arg = "stage" if show_stage else arg
         arg = "ref" if show_ref else arg
         if arg:
+            if not output[0]:
+                return
             if arg not in output[0][0]:
                 raise WrongArgs(f"Cannot apply --{arg}")
             format_echo(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -497,6 +497,11 @@ def test_show_ref_flag_not_applicable(repo_with_commit: str):
     )
 
 
+def test_show_line_flag_empty_result():
+    with mock.patch("gto.api.show", return_value=([], "keys")):
+        _check_successful_cmd("show", ["-r", ".", "m5#missing", "--version"], "")
+
+
 def test_history_json_empty(repo_with_commit: str):
     _check_successful_cmd("history", ["-r", repo_with_commit, "--json"], "[]\n")
 


### PR DESCRIPTION
## Summary

Fixes #344 by making `gto show <artifact>#<missing-stage> --version` return an empty successful output instead of raising `list index out of range` when the underlying show result is empty.

## Changes

- Guard `show` line-format output before indexing into an empty table result.
- Preserve the existing `Cannot apply --<arg>` validation for non-empty results that do not support the requested line flag.
- Add a regression test for an empty `show --version` result.

## Verification

- `pytest tests/test_cli.py::test_show_line_flag_empty_result tests/test_cli.py::test_commands tests/test_cli.py::test_show_ref_flag_not_applicable -q`
- `pytest -q`
  - 189 passed, 1 warning
- `python -m py_compile gto/*.py`
- `git diff --check`