### PR TITLE
fix: quote git push tag suggestions

### DIFF
--- a/gto/registry.py
+++ b/gto/registry.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import shlex
 from contextlib import contextmanager
 from typing import List, Optional, TypeVar, cast
 
@@ -485,7 +486,8 @@ class GitRegistry(BaseModel, RemoteRepoMixin):
     @staticmethod
     def _echo_git_suggestion(tag, delete=False):
         echo("To push the changes upstream, run:")
-        echo(f"    git push{' --delete ' if delete else ' '}origin {tag}")
+        quoted_tag = shlex.quote(tag)
+        echo(f"    git push{' --delete ' if delete else ' '}origin {quoted_tag}")
 
     def _delete_tags(self, tags, stdout, push: bool):
         tags = list(tags)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -248,7 +248,7 @@ def test_register(repo_with_commit: str):
         ["-r", repo_with_commit, "a2", "v1.2.3"],
         "Created git tag 'a2@v1.2.3!' that deregisters version\n"
         "To push the changes upstream, run:\n"
-        "    git push origin a2@v1.2.3!\n",
+        "    git push origin 'a2@v1.2.3!'\n",
     )
 
     _check_successful_cmd(
@@ -256,7 +256,7 @@ def test_register(repo_with_commit: str):
         ["-r", repo_with_commit, "a2", "--simple", "false"],
         "Created git tag 'a2@v1.2.3#1' that registers version\n"
         "To push the changes upstream, run:\n"
-        "    git push origin a2@v1.2.3#1\n",
+        "    git push origin 'a2@v1.2.3#1'\n",
     )
 
     _check_failing_cmd(
@@ -287,7 +287,7 @@ def test_assign(repo_with_commit: str):
         ["-r", repo_with_commit, "nn1", "HEAD", "--stage", "prod"],
         "Created git tag 'nn1#prod#1' that assigns stage to version 'v0.0.1'\n"
         "To push the changes upstream, run:\n"
-        "    git push origin nn1#prod#1\n",
+        "    git push origin 'nn1#prod#1'\n",
     )
     # this check depends on the previous assignment
     _check_failing_cmd(
@@ -328,7 +328,7 @@ def test_assign(repo_with_commit: str):
         "    git push origin nn2@v0.0.1\n"
         "Created git tag 'nn2#prod#1' that assigns stage to version 'v0.0.1'\n"
         "To push the changes upstream, run:\n"
-        "    git push origin nn2#prod#1\n",
+        "    git push origin 'nn2#prod#1'\n",
     )
 
 


### PR DESCRIPTION
## Summary

Fixes #114 by shell-quoting tag names in the `git push` suggestions printed after creating/deleting GTO tags.

## Changes

- Use `shlex.quote()` when rendering the suggested tag argument.
- Preserve unquoted suggestions for shell-safe tag names such as `a1@v0.0.1`.
- Quote tags containing shell-significant characters like `#` and `!`, e.g. `git push origin 'nn1#prod#1'`.
- Update CLI regression expectations for register/assign suggestions.

## Verification

- `pytest tests/test_cli.py::test_register tests/test_cli.py::test_assign -q`
- `pytest -q`
  - 188 passed, 1 warning
- `python -m py_compile gto/*.py`
- `git diff --check`