### PR TITLE
fix simple/sort annotations to match callback return types

### DIFF
--- a/gto/api.py
+++ b/gto/api.py
@@ -111,7 +111,7 @@ def assign(
     ref: Optional[str] = None,
     name_version: Optional[str] = None,
     message: Optional[str] = None,
-    simple: bool = False,
+    simple: Optional[bool] = False,
     force: bool = False,
     push: bool = False,
     skip_registration: bool = False,

--- a/gto/cli.py
+++ b/gto/cli.py
@@ -458,7 +458,7 @@ def register(
     ref: str,
     version: Optional[str],
     message: Optional[str],
-    simple: str,
+    simple: Optional[bool],
     force: bool,
     bump_major: bool,
     bump_minor: bool,
@@ -474,7 +474,7 @@ def register(
         ref=ref or "HEAD",
         version=version,
         message=message,
-        simple=simple,  # type: ignore
+        simple=simple,
         force=force,
         bump_major=bump_major,
         bump_minor=bump_minor,
@@ -511,7 +511,7 @@ def assign(
     version: Optional[str],
     stage: str,
     message: Optional[str],
-    simple: str,
+    simple: Optional[bool],
     force: bool,
     push: bool,
     skip_registration: bool,
@@ -534,7 +534,7 @@ def assign(
         ref,
         name_version,
         message=message,
-        simple=simple,  # type: ignore
+        simple=simple,
         force=force,
         push=push,
         skip_registration=skip_registration,
@@ -560,7 +560,7 @@ def deprecate(
     stage: Optional[str],
     ref: Optional[str],
     message: Optional[str],
-    simple: str,
+    simple: Optional[bool],
     force: bool,
     delete: bool,
     push: bool,
@@ -573,7 +573,7 @@ def deprecate(
             version=version,
             stage=stage,
             message=message,
-            simple=simple,  # type: ignore
+            simple=simple,
             force=force,
             delete=delete,
             push=push,
@@ -585,7 +585,7 @@ def deprecate(
             name=name,
             version=version,
             message=message,
-            simple=simple,  # type: ignore
+            simple=simple,
             force=force,
             delete=delete,
             push=push,
@@ -597,7 +597,7 @@ def deprecate(
             name=name,
             ref=ref,
             message=message,
-            simple=simple,  # type: ignore
+            simple=simple,
             force=force,
             delete=delete,
             push=push,
@@ -695,7 +695,7 @@ def show(  # pylint: disable=too-many-locals
     deprecated: bool,
     assignments_per_version: int,
     versions_per_stage: int,
-    sort: str,
+    sort: VersionSort,
 ):
     """Show the registry state, highest version, or what's assigned in stage."""
     show_options = [show_name, show_version, show_stage, show_ref]


### PR DESCRIPTION
Follow-up to #499, addressing [Copilot's post-merge review comments](https://github.com/iterative/gto/pull/499#pullrequestreview-4183341073): `callback_simple` normalizes `--simple` to `None|bool` and `callback_sort` returns `VersionSort`, but the command params were annotated `str` (carried over from the typer version). Annotate them truthfully and drop the five `# type: ignore` comments that the wrong annotations forced. `api.assign`'s `simple` accepts `None` ("auto") at runtime, so it becomes `Optional[bool]` too.

No behavior change — mypy now passes without any ignores; full suite (188) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)